### PR TITLE
Allow passing ignores via the command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ This will list all the unused dependencies in your code if any.
 
 `--no-dev` : by default `depcheck` looks at `dependencies` and `devDependencies`, this flag will tell it not to look at "devDependencies".
 
-`--json` : output results to JSON
+`--json` : output results to JSON.
+
+`--ignores`: a comma separated package list to ignore. It could be glob expressions.
 
 Or, as a lib:
 ```javascript

--- a/bin/depcheck
+++ b/bin/depcheck
@@ -6,9 +6,15 @@ var optimist = require('optimist')
   .default('dev', true)
   .describe('no-dev', 'Don\'t look at devDependecies')
   .describe('json', 'Output results to JSON')
-  .describe('ignores', 'Comma separated package list to ignore');
+  .describe('ignores', 'Comma separated package list to ignore')
+  .describe('help', 'Show this help message');
 
 var argv = optimist.argv;
+
+if (argv.help) {
+  console.log(optimist.help());
+  process.exit(0);
+}
 
 var checkDirectory = require('../index');
 var fs = require('fs');

--- a/bin/depcheck
+++ b/bin/depcheck
@@ -6,7 +6,7 @@ var optimist = require('optimist')
   .default('dev', true)
   .describe('no-dev', 'Don\'t look at devDependecies')
   .describe('json', 'Output results to JSON')
-  .describe('ignores', 'comma separated list of packages to ignore');
+  .describe('ignores', 'Comma separated package list to ignore');
 
 var argv = optimist.argv;
 

--- a/bin/depcheck
+++ b/bin/depcheck
@@ -5,7 +5,8 @@ var optimist = require('optimist')
   .boolean('dev')
   .default('dev', true)
   .describe('no-dev', 'Don\'t look at devDependecies')
-  .describe('json', 'Output results to JSON');
+  .describe('json', 'Output results to JSON')
+  .describe('ignores', 'comma separated list of packages to ignore');
 
 var argv = optimist.argv;
 
@@ -33,7 +34,10 @@ fs.exists(absolutePath, function (pathExists) {
 });
 
 function run() {
-  checkDirectory(absolutePath, { "withoutDev": !argv.dev }, function (unused) {
+  checkDirectory(absolutePath, {
+    "withoutDev": !argv.dev,
+    "ignoreMatches": (argv.ignores || "").split(",")
+  }, function (unused) {
     if (argv.json) {
       console.log(JSON.stringify(unused));
       return process.exit(0);


### PR DESCRIPTION
\cc @gtanner @siimon

Hi,

After fork depcheck and publish the [depcheck-es6](https://www.npmjs.com/package/depcheck-es6), I look into other forks for PRs. It shows that you are implementing a feature to pass ignore packages from command line.

Please look into my changes, which is based on @gtanner 's fork. If there is any issue, please comment on it.

---

Reference: rumpl/depcheck#34 and rumpl/depcheck#30
