### PR TITLE
Additional ES6 import tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+*.swp

--- a/test/fake_modules/bad_es6/index.js
+++ b/test/fake_modules/bad_es6/index.js
@@ -2,7 +2,7 @@
  * This should cover all styles of ES6 imports as described by:
  * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import
  */
-import "basic-import";
+import "jquery";
 import name from "name-import";
 import * as star from "star-import";
 import { member } from "member-import";

--- a/test/fake_modules/bad_es6/index.js
+++ b/test/fake_modules/bad_es6/index.js
@@ -2,7 +2,7 @@
  * This should cover all styles of ES6 imports as described by:
  * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import
  */
-import "jquery";
+import "find-me";
 import name from "name-import";
 import * as star from "star-import";
 import { member } from "member-import";

--- a/test/fake_modules/bad_es6/index.js
+++ b/test/fake_modules/bad_es6/index.js
@@ -10,6 +10,5 @@ import { foobar as barfoo } from "member-alias-import";
 import { foo , bar } from "multiple-member-import";
 import { a, b as c } from "mixed-member-alias-import";
 import d, { e } from "mixed-name-memeber-import";
-import "name-import-as" as fg;
 import h, * as i from "mixed-default-star-import";
 import j from "default-member-import";

--- a/test/fake_modules/bad_es6/package.json
+++ b/test/fake_modules/bad_es6/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "optimist": "~0.6.0",
+    "dont-find-me": "~0.0.1",
     "find-me": "^0.1.0"
   }
 }

--- a/test/fake_modules/bad_es6/package.json
+++ b/test/fake_modules/bad_es6/package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "optimist": "~0.6.0",
+    "jquery": "^2.1.4"
+  }
+}

--- a/test/fake_modules/bad_es6/package.json
+++ b/test/fake_modules/bad_es6/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
     "optimist": "~0.6.0",
-    "jquery": "^2.1.4"
+    "find-me": "^0.1.0"
   }
 }

--- a/test/fake_modules/good_es6/index.js
+++ b/test/fake_modules/good_es6/index.js
@@ -1,5 +1,5 @@
 /**
- * This should cover all styles of ES6 imports as described by:
+ * This should cover (nearly) all ES6 import syntaxes as described by:
  * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import
  */
 import "basic-import";
@@ -12,3 +12,18 @@ import { a, b as c } from "mixed-member-alias-import";
 import d, { e } from "mixed-name-memeber-import";
 import h, * as i from "mixed-default-star-import";
 import j from "default-member-import";
+
+// import "unsupportedSyntax" as seeBelow;
+/*
+ * The import syntax shown on MDN as `import "module-name" as name;` is
+ * currently unsupported.
+ *
+ * This is due to it being unsupported by the JavaScript parsing libraries that
+ * we use.
+ *
+ * Additionally, this syntax is not supported by Babel (currently), so we felt
+ * that it was reasonable to not support it at this time. We've left this here
+ * for future reference.
+ *
+ * https://github.com/lijunle/depcheck-es6/pull/7
+ */

--- a/test/fake_modules/good_es6/index.js
+++ b/test/fake_modules/good_es6/index.js
@@ -10,6 +10,5 @@ import { foobar as barfoo } from "member-alias-import";
 import { foo , bar } from "multiple-member-import";
 import { a, b as c } from "mixed-member-alias-import";
 import d, { e } from "mixed-name-memeber-import";
-import "name-import-as" as fg;
 import h, * as i from "mixed-default-star-import";
 import j from "default-member-import";

--- a/test/fake_modules/good_es6/package.json
+++ b/test/fake_modules/good_es6/package.json
@@ -8,8 +8,8 @@
     "multiple-member-import": "1.2.3",
     "mixed-member-alias-import": "1.2.3",
     "mixed-name-memeber-import": "1.2.3",
-    "name-import-as": "1.2.3",
     "mixed-default-star-import": "1.2.3",
-    "default-member-import": "1.2.3"
+    "default-member-import": "1.2.3",
+    "unsupported-syntax": "1.2.3"
   }
 }

--- a/test/fake_modules/good_es6/package.json
+++ b/test/fake_modules/good_es6/package.json
@@ -1,5 +1,15 @@
 {
   "dependencies": {
-    "module_good_es6": "~0.0.1"
+    "basic-import": "1.2.3",
+    "name-import": "1.2.3",
+    "star-import": "1.2.3",
+    "member-import": "1.2.3",
+    "member-alias-import": "1.2.3",
+    "multiple-member-import": "1.2.3",
+    "mixed-member-alias-import": "1.2.3",
+    "mixed-name-memeber-import": "1.2.3",
+    "name-import-as": "1.2.3",
+    "mixed-default-star-import": "1.2.3",
+    "default-member-import": "1.2.3"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -14,6 +14,15 @@ describe("depcheck", function () {
     });
   });
 
+  it("should find unused dependencies in ES6 files", function testUnused(done) {
+    var absolutePath = path.resolve("test/fake_modules/bad_es6");
+
+    depcheck(absolutePath, { "withoutDev": true }, function checked(unused) {
+      assert.equal(unused.dependencies.length, 1);
+      done();
+    });
+  });
+
   it("should find all dependencies", function testUnused(done) {
     var absolutePath = path.resolve("test/fake_modules/good");
 

--- a/test/index.js
+++ b/test/index.js
@@ -19,6 +19,7 @@ describe("depcheck", function () {
 
     depcheck(absolutePath, { "withoutDev": true }, function checked(unused) {
       assert.equal(unused.dependencies.length, 1);
+      assert.equal(unused.dependencies[0], "dont-find-me");
       done();
     });
   });
@@ -37,6 +38,7 @@ describe("depcheck", function () {
 
     depcheck(absolutePath, { "withoutDev": true }, function checked(unused) {
       assert.equal(unused.dependencies.length, 1);
+      assert.equal(unused.dependencies[0], "name-import-as");
       done();
     });
   });

--- a/test/index.js
+++ b/test/index.js
@@ -36,7 +36,7 @@ describe("depcheck", function () {
     var absolutePath = path.resolve("test/fake_modules/good_es6");
 
     depcheck(absolutePath, { "withoutDev": true }, function checked(unused) {
-      assert.equal(unused.dependencies.length, 0);
+      assert.equal(unused.dependencies.length, 1);
       done();
     });
   });

--- a/test/index.js
+++ b/test/index.js
@@ -37,8 +37,10 @@ describe("depcheck", function () {
     var absolutePath = path.resolve("test/fake_modules/good_es6");
 
     depcheck(absolutePath, { "withoutDev": true }, function checked(unused) {
+      // See ./good_es6/index.js for more information on the unsupported ES6
+      // import syntax, which we assert here as the expected missing import.
       assert.equal(unused.dependencies.length, 1);
-      assert.equal(unused.dependencies[0], "name-import-as");
+      assert.equal(unused.dependencies[0], "unsupported-syntax");
       done();
     });
   });


### PR DESCRIPTION
I've updated the test suite to include ES6 style imports (all ES6 style imports) as described by [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import) and discovered that the following syntax causes depcheck to assign all modules as unused.
