### PR TITLE
Store syntax-error files to invalidFiles property.

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ function getModulesRequiredFromFilename(filename, options) {
 
     return dependencies;
   } catch (err) {
-    return [];
+    return err;
   }
 }
 

--- a/test/fake_modules/bad_js/deeper/also_bad_js.js
+++ b/test/fake_modules/bad_js/deeper/also_bad_js.js
@@ -1,7 +1,0 @@
-
-// there's a ) missing which will make it impossible parse
-;["util","assert"].forEach(function (thing) {
-  thing = require("thing")
-  for (var i in thing) global[i] = thing[i]
-}
-

--- a/test/index.js
+++ b/test/index.js
@@ -95,8 +95,15 @@ describe("depcheck", function () {
     var absolutePath = path.resolve("test/fake_modules/bad_js");
 
     depcheck(absolutePath, {  }, function checked(unused) {
-      assert.equal(unused.dependencies.length, 1);
-      //assert.deepEqual(Object.keys(unused.invalidFiles).length, 2);
+      unused.dependencies.should.have.length(1);
+
+      var invalidFiles = Object.keys(unused.invalidFiles);
+      invalidFiles.should.have.length(1);
+      invalidFiles[0].should.endWith('/test/fake_modules/bad_js/index.js');
+
+      var error = unused.invalidFiles[invalidFiles[0]];
+      error.should.be.instanceof(SyntaxError);
+
       done();
     });
   });


### PR DESCRIPTION
- This is the rumpl's depcheck behavior. Be compatible with it.
- Add test case to cover scenario.

Close #13 #9 
