### PR TITLE
Handle walkdir access error.

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,6 +59,7 @@ function checkDirectory(dir, ignoreDirs, deps, devDeps, options) {
   var directoryPromises = [];
   var finder = walkdir(dir, { "no_recurse": true });
   var invalidFiles = {};
+  var invalidDirs = {};
 
   finder.on("directory", function (subdir) {
     if (_.contains(ignoreDirs, path.basename(subdir))
@@ -94,21 +95,26 @@ function checkDirectory(dir, ignoreDirs, deps, devDeps, options) {
           deps = _.intersection(deps, result.value.dependencies);
           devDeps = _.intersection(devDeps, result.value.devDependencies);
         } else {
-          deferred.reject(result.reason);
+          var path = result.reason.path;
+          var error = result.reason.error;
+          invalidDirs[path] = error;
         }
       });
 
       return {
         dependencies: deps,
         devDependencies: devDeps,
-        invalidFiles: invalidFiles
+        invalidFiles: invalidFiles,
+        invalidDirs: invalidDirs
       };
     }));
   });
 
   finder.on("error", function (path, err) {
-    console.error(err.message);
-    deferred.reject(err);
+    deferred.reject({
+      path: path,
+      error: err
+    });
   });
 
   return deferred.promise;

--- a/index.js
+++ b/index.js
@@ -93,6 +93,8 @@ function checkDirectory(dir, ignoreDirs, deps, devDeps, options) {
           invalidFiles = _.merge(invalidFiles, result.value.invalidFiles, {});
           deps = _.intersection(deps, result.value.dependencies);
           devDeps = _.intersection(devDeps, result.value.devDependencies);
+        } else {
+          deferred.reject(result.reason);
         }
       });
 
@@ -102,6 +104,11 @@ function checkDirectory(dir, ignoreDirs, deps, devDeps, options) {
         invalidFiles: invalidFiles
       };
     }));
+  });
+
+  finder.on("error", function (path, err) {
+    console.error(err.message);
+    deferred.reject(err);
   });
 
   return deferred.promise;

--- a/test/index.js
+++ b/test/index.js
@@ -2,6 +2,7 @@
 
 var assert = require("should");
 var depcheck = require("../index");
+var fs = require("fs");
 var path = require("path");
 
 describe("depcheck", function () {
@@ -178,4 +179,24 @@ describe("depcheck", function () {
     });
   });
 
+  describe("#error-handling", function () {
+    var absolutePath = path.resolve("test/fake_modules/bad");
+    var unreadableDir = path.join(absolutePath, 'unreadable');
+
+    before(function createUnreadableDir() {
+      fs.mkdirSync(unreadableDir, '0000');
+    });
+
+    it("should handle walkdir errors", function testNonReadable(done) {
+      depcheck(absolutePath, {  }, function checked(unused) {
+        assert.equal(unused.dependencies.length, 1);
+        done();
+      });
+    });
+
+    after(function removeUnreadableDir() {
+      fs.chmodSync(unreadableDir, '0700');
+      fs.rmdirSync(unreadableDir);
+    });
+  });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -179,24 +179,19 @@ describe("depcheck", function () {
     });
   });
 
-  describe("#error-handling", function () {
+  it('should handle directory access error', function testNonReadable(done) {
     var absolutePath = path.resolve("test/fake_modules/bad");
     var unreadableDir = path.join(absolutePath, 'unreadable');
 
-    before(function createUnreadableDir() {
-      fs.mkdirSync(unreadableDir, '0000');
-    });
+    fs.mkdirSync(unreadableDir, '0000');
 
-    it("should handle walkdir errors", function testNonReadable(done) {
-      depcheck(absolutePath, {  }, function checked(unused) {
-        assert.equal(unused.dependencies.length, 1);
-        done();
-      });
-    });
+    depcheck(absolutePath, {  }, function checked(unused) {
+      assert.equal(unused.dependencies.length, 1);
 
-    after(function removeUnreadableDir() {
       fs.chmodSync(unreadableDir, '0700');
       fs.rmdirSync(unreadableDir);
+
+      done();
     });
   });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -188,6 +188,14 @@ describe("depcheck", function () {
     depcheck(absolutePath, {  }, function checked(unused) {
       assert.equal(unused.dependencies.length, 1);
 
+      var invalidDirs = Object.keys(unused.invalidDirs);
+      invalidDirs.should.have.length(1);
+      invalidDirs[0].should.endWith('/test/fake_modules/bad/unreadable');
+
+      var error = unused.invalidDirs[invalidDirs[0]];
+      error.should.be.instanceof(Error);
+      error.toString().should.containEql('EACCES');
+
       fs.chmodSync(unreadableDir, '0700');
       fs.rmdirSync(unreadableDir);
 


### PR DESCRIPTION
- Add `invalidDirs` to store the directory report the error.
- Add test case to cover this scenario
- Increase the branch test coverage to **95.24%**
