### PR TITLE
Prepare version 0.5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,18 +56,10 @@ var root = path.resolve("some path");
 depcheck(root, options, function(unused) {
   console.log(unused.dependencies);
   console.log(unused.devDependencies);
-  console.log(unused.invalidFiles); // JS files that couldn't be parsed
+  console.log(unused.invalidFiles); // JavaScript files that cannot parse
+  console.log(unused.invalidDirs); // directories that cannot access
 });
 ```
-
-## TODOs
-
-Well, it's more of a "What do you think guys?".
-
-There are a couple of things I would like to do if anyone is interested:
-
- - There could be false positives, we could have a white list of modules that
-you know you are using and that `depcheck` can't find in your code
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "depcheck-es6",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Check dependencies in your node module",
   "main": "index",
   "bin": {


### PR DESCRIPTION
Diff from the previous release: https://github.com/lijunle/depcheck-es6/compare/0.5.0...0.5.1

Change log:
- Provide `ignores` option in depcheck command line utility.
- Show help message in depcheck command line utility.
- Store the directory that cannot access to `invalidDirs` property in the JSON output. (Check the [test case](https://github.com/lijunle/depcheck-es6/blob/58fed0956e05047df87d826afecde414eaa99688/test/index.js#L183-L202) for more information.)
- Speed up check when there is no dependencies and dev-dependencies installed.
- **Fix** the bug about storing parse error files to `invalidFiles` in JSON output.
- **Breaking change**: the depcheck option will not pass to acorn parser. This functionality will be provided in the [pluggable desing](https://github.com/lijunle/depcheck-es6/issues/27) in the next release.
