### PR TITLE
Resolve Most of ESLint Warnings

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -26,23 +26,6 @@ var path = require('path');
 var dir = argv._[0] || '.';
 var absolutePath = path.resolve(dir);
 
-fs.exists(absolutePath, pathExists => {
-  if (pathExists) {
-    fs.exists(absolutePath + path.sep + 'package.json', exists => {
-      if (exists) {
-        run();
-      } else {
-        console.error('Path ' + dir + ' does not contain a package.json file');
-        opt.showHelp();
-        process.exit(-1);
-      }
-    });
-  } else {
-    console.error('Path ' + dir + ' does not exist');
-    process.exit(-1);
-  }
-});
-
 function run() {
   checkDirectory(absolutePath, {
     "withoutDev": !argv.dev,
@@ -74,3 +57,20 @@ function run() {
     }
   });
 }
+
+fs.exists(absolutePath, pathExists => {
+  if (pathExists) {
+    fs.exists(absolutePath + path.sep + 'package.json', exists => {
+      if (exists) {
+        run();
+      } else {
+        console.error('Path ' + dir + ' does not contain a package.json file');
+        opt.showHelp();
+        process.exit(-1);
+      }
+    });
+  } else {
+    console.error('Path ' + dir + ' does not exist');
+    process.exit(-1);
+  }
+});

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+/* eslint-disable no-console */
+
 import optimist from 'optimist';
 
 var opt = optimist

--- a/src/cli.js
+++ b/src/cli.js
@@ -24,9 +24,9 @@ var path = require('path');
 var dir = argv._[0] || '.';
 var absolutePath = path.resolve(dir);
 
-fs.exists(absolutePath, function (pathExists) {
+fs.exists(absolutePath, pathExists => {
   if (pathExists) {
-    fs.exists(absolutePath + path.sep + 'package.json', function (exists) {
+    fs.exists(absolutePath + path.sep + 'package.json', exists => {
       if (exists) {
         run();
       } else {
@@ -45,7 +45,7 @@ function run() {
   checkDirectory(absolutePath, {
     "withoutDev": !argv.dev,
     "ignoreMatches": (argv.ignores || "").split(","),
-  }, function (unused) {
+  }, unused => {
     if (argv.json) {
       console.log(JSON.stringify(unused));
       return process.exit(0);
@@ -57,14 +57,14 @@ function run() {
     } else {
       if (unused.dependencies.length !== 0) {
         console.log('Unused Dependencies');
-        unused.dependencies.forEach(function (u) {
+        unused.dependencies.forEach(u => {
           console.log('* ' + u);
         });
       }
       if (unused.devDependencies.length !== 0) {
         console.log();
         console.log('Unused devDependencies');
-        unused.devDependencies.forEach(function (u) {
+        unused.devDependencies.forEach(u => {
           console.log('* ' + u);
         });
       }

--- a/src/cli.js
+++ b/src/cli.js
@@ -4,7 +4,7 @@
 
 import optimist from 'optimist';
 
-var opt = optimist
+const opt = optimist
   .usage('Usage: $0 [DIRECTORY]')
   .boolean('dev')
   .default('dev', true)
@@ -13,18 +13,18 @@ var opt = optimist
   .describe('ignores', 'Comma separated package list to ignore')
   .describe('help', 'Show this help message');
 
-var argv = opt.argv;
+const argv = opt.argv;
 
 if (argv.help) {
   console.log(opt.help());
   process.exit(0);
 }
 
-var checkDirectory = require('./index');
-var fs = require('fs');
-var path = require('path');
-var dir = argv._[0] || '.';
-var absolutePath = path.resolve(dir);
+const checkDirectory = require('./index');
+const fs = require('fs');
+const path = require('path');
+const dir = argv._[0] || '.';
+const absolutePath = path.resolve(dir);
 
 function run() {
   checkDirectory(absolutePath, {

--- a/src/cli.js
+++ b/src/cli.js
@@ -44,7 +44,7 @@ fs.exists(absolutePath, function (pathExists) {
 function run() {
   checkDirectory(absolutePath, {
     "withoutDev": !argv.dev,
-    "ignoreMatches": (argv.ignores || "").split(",")
+    "ignoreMatches": (argv.ignores || "").split(","),
   }, function (unused) {
     if (argv.json) {
       console.log(JSON.stringify(unused));

--- a/src/cli.js
+++ b/src/cli.js
@@ -28,8 +28,8 @@ const absolutePath = path.resolve(dir);
 
 function run() {
   checkDirectory(absolutePath, {
-    "withoutDev": !argv.dev,
-    "ignoreMatches": (argv.ignores || "").split(","),
+    'withoutDev': !argv.dev,
+    'ignoreMatches': (argv.ignores || '').split(','),
   }, unused => {
     if (argv.json) {
       console.log(JSON.stringify(unused));

--- a/src/index.js
+++ b/src/index.js
@@ -89,7 +89,6 @@ function checkDirectory(dir, ignoreDirs, deps, devDeps) {
 
   finder.on("end", () => {
     deferred.resolve(q.allSettled(directoryPromises).then(directoryResults => {
-
       _.each(directoryResults, result => {
         if (result.state === 'fulfilled') {
           invalidFiles = _.merge(invalidFiles, result.value.invalidFiles, {});
@@ -145,7 +144,6 @@ function filterDependencies(rootDir, ignoreMatches, dependencies) {
 }
 
 function depCheck(rootDir, options, cb) {
-
   const pkg = options.package || require(path.join(rootDir, 'package.json'));
   const deps = filterDependencies(rootDir, options.ignoreMatches, pkg.dependencies);
   const devDeps = filterDependencies(rootDir, options.ignoreMatches, options.withoutDev ? [] : pkg.devDependencies);

--- a/src/index.js
+++ b/src/index.js
@@ -39,7 +39,7 @@ function getModulesRequiredFromFilename(filename) {
   var dependencies = [];
 
   try {
-    walker.walk(content, function(node) {
+    walker.walk(content, node => {
       if (isRequireFunction(node) || isGruntLoadTaskCall(node)) {
         dependencies.push(getArgumentFromCall(node));
       } else if (isImportDeclaration(node)) {
@@ -64,7 +64,7 @@ function checkDirectory(dir, ignoreDirs, deps, devDeps) {
     finder.emit('end');
   }
 
-  finder.on("directory", function (subdir) {
+  finder.on("directory", subdir => {
     if (_.contains(ignoreDirs, path.basename(subdir)))  {
       return;
     }
@@ -72,13 +72,13 @@ function checkDirectory(dir, ignoreDirs, deps, devDeps) {
     directoryPromises.push(checkDirectory(subdir, ignoreDirs, deps, devDeps));
   });
 
-  finder.on("file", function (filename) {
+  finder.on("file", filename => {
     if (path.extname(filename) === ".js") {
       var modulesRequired = getModulesRequiredFromFilename(filename);
       if (util.isError(modulesRequired)) {
         invalidFiles[filename] = modulesRequired;
       } else {
-        modulesRequired = modulesRequired.map(function (module) {
+        modulesRequired = modulesRequired.map(module => {
           return module.replace ? module.replace(/\/.*$/, '') : module;
         });
         deps = _.difference(deps, modulesRequired);
@@ -87,10 +87,10 @@ function checkDirectory(dir, ignoreDirs, deps, devDeps) {
     }
   });
 
-  finder.on("end", function () {
-    deferred.resolve(q.allSettled(directoryPromises).then(function(directoryResults) {
+  finder.on("end", () => {
+    deferred.resolve(q.allSettled(directoryPromises).then(directoryResults => {
 
-      _.each(directoryResults, function(result) {
+      _.each(directoryResults, result => {
         if (result.state === 'fulfilled') {
           invalidFiles = _.merge(invalidFiles, result.value.invalidFiles, {});
           deps = _.intersection(deps, result.value.dependencies);
@@ -111,7 +111,7 @@ function checkDirectory(dir, ignoreDirs, deps, devDeps) {
     }));
   });
 
-  finder.on("error", function (path, err) {
+  finder.on("error", (path, err) => {
     deferred.reject({
       path: path,
       error: err,
@@ -140,7 +140,7 @@ function depCheck(rootDir, options, cb) {
     .valueOf();
 
   function isIgnored(dependency) {
-    return _.any(options.ignoreMatches, function(match) {
+    return _.any(options.ignoreMatches, match => {
       return minimatch(dependency, match);
     });
   }

--- a/src/index.js
+++ b/src/index.js
@@ -96,7 +96,7 @@ function checkDirectory(dir, ignoreDirs, deps, devDeps) {
           deps = _.intersection(deps, result.value.dependencies);
           devDeps = _.intersection(devDeps, result.value.devDependencies);
         } else {
-          var dirPath = result.reason.path;
+          var dirPath = result.reason.dirPath;
           var error = result.reason.error;
           invalidDirs[dirPath] = error;
         }

--- a/src/index.js
+++ b/src/index.js
@@ -106,7 +106,7 @@ function checkDirectory(dir, ignoreDirs, deps, devDeps) {
         dependencies: deps,
         devDependencies: devDeps,
         invalidFiles: invalidFiles,
-        invalidDirs: invalidDirs
+        invalidDirs: invalidDirs,
       };
     }));
   });
@@ -114,7 +114,7 @@ function checkDirectory(dir, ignoreDirs, deps, devDeps) {
   finder.on("error", function (path, err) {
     deferred.reject({
       path: path,
-      error: err
+      error: err,
     });
   });
 
@@ -132,7 +132,7 @@ function depCheck(rootDir, options, cb) {
       '.hg',
       '.idea',
       'node_modules',
-      'bower_components'
+      'bower_components',
     ])
     .concat(options.ignoreDirs)
     .flatten()

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,8 @@
-import fs from "fs";
-import path from "path";
+import fs from 'fs';
+import path from 'path';
 import Walker from 'node-source-walk';
 import q from 'q';
-import walkdir from "walkdir";
+import walkdir from 'walkdir';
 import _ from 'lodash';
 import minimatch from 'minimatch';
 import util from 'util';
@@ -30,7 +30,7 @@ function isImportDeclaration(node) {
 }
 
 function getModulesRequiredFromFilename(filename) {
-  const content = fs.readFileSync(filename, "utf-8");
+  const content = fs.readFileSync(filename, 'utf-8');
   if (!content) {
     return [];
   }
@@ -56,7 +56,7 @@ function getModulesRequiredFromFilename(filename) {
 function checkDirectory(dir, ignoreDirs, deps, devDeps) {
   const deferred = q.defer();
   const directoryPromises = [];
-  const finder = walkdir(dir, { "no_recurse": true });
+  const finder = walkdir(dir, { 'no_recurse': true });
   let invalidFiles = {};
   const invalidDirs = {};
 
@@ -64,7 +64,7 @@ function checkDirectory(dir, ignoreDirs, deps, devDeps) {
     finder.emit('end');
   }
 
-  finder.on("directory", subdir => {
+  finder.on('directory', subdir => {
     if (_.contains(ignoreDirs, path.basename(subdir)))  {
       return;
     }
@@ -72,8 +72,8 @@ function checkDirectory(dir, ignoreDirs, deps, devDeps) {
     directoryPromises.push(checkDirectory(subdir, ignoreDirs, deps, devDeps));
   });
 
-  finder.on("file", filename => {
-    if (path.extname(filename) === ".js") {
+  finder.on('file', filename => {
+    if (path.extname(filename) === '.js') {
       let modulesRequired = getModulesRequiredFromFilename(filename);
       if (util.isError(modulesRequired)) {
         invalidFiles[filename] = modulesRequired;
@@ -87,7 +87,7 @@ function checkDirectory(dir, ignoreDirs, deps, devDeps) {
     }
   });
 
-  finder.on("end", () => {
+  finder.on('end', () => {
     deferred.resolve(q.allSettled(directoryPromises).then(directoryResults => {
       _.each(directoryResults, result => {
         if (result.state === 'fulfilled') {
@@ -110,7 +110,7 @@ function checkDirectory(dir, ignoreDirs, deps, devDeps) {
     }));
   });
 
-  finder.on("error", (dirPath, err) => {
+  finder.on('error', (dirPath, err) => {
     deferred.reject({
       dirPath: dirPath,
       error: err,
@@ -128,7 +128,7 @@ function isIgnored(ignoreMatches, dependency) {
 
 function hasBin(rootDir, dependency) {
   try {
-    const depPkg = require(path.join(rootDir, "node_modules", dependency, "package.json"));
+    const depPkg = require(path.join(rootDir, 'node_modules', dependency, 'package.json'));
     return _.has(depPkg, 'bin');
   } catch (e) {
     return false;

--- a/src/index.js
+++ b/src/index.js
@@ -96,9 +96,9 @@ function checkDirectory(dir, ignoreDirs, deps, devDeps) {
           deps = _.intersection(deps, result.value.dependencies);
           devDeps = _.intersection(devDeps, result.value.devDependencies);
         } else {
-          var path = result.reason.path;
+          var dirPath = result.reason.path;
           var error = result.reason.error;
-          invalidDirs[path] = error;
+          invalidDirs[dirPath] = error;
         }
       });
 
@@ -111,9 +111,9 @@ function checkDirectory(dir, ignoreDirs, deps, devDeps) {
     }));
   });
 
-  finder.on("error", (path, err) => {
+  finder.on("error", (dirPath, err) => {
     deferred.reject({
-      path: path,
+      dirPath: dirPath,
       error: err,
     });
   });
@@ -151,7 +151,9 @@ function depCheck(rootDir, options, cb) {
     try {
       var depPkg = require(path.join(rootDir, "node_modules", dependency, "package.json"));
       return _.has(depPkg, 'bin');
-    } catch (e) {}
+    } catch (e) {
+      return false;
+    }
   }
 
   function filterDependencies(dependencies) {

--- a/src/index.js
+++ b/src/index.js
@@ -14,13 +14,13 @@ function getArgumentFromCall(node) {
 }
 
 function isRequireFunction(node) {
-  var callee = node.callee;
+  const callee = node.callee;
   return callee && callee.type === 'Identifier' && callee.name === 'require' &&
     getArgumentFromCall(node);
 }
 
 function isGruntLoadTaskCall(node) {
-  var callee = node.callee;
+  const callee = node.callee;
   return callee && callee.property && callee.property.name === 'loadNpmTasks' &&
     getArgumentFromCall(node);
 }
@@ -30,13 +30,13 @@ function isImportDeclaration(node) {
 }
 
 function getModulesRequiredFromFilename(filename) {
-  var content = fs.readFileSync(filename, "utf-8");
+  const content = fs.readFileSync(filename, "utf-8");
   if (!content) {
     return [];
   }
 
-  var walker = new Walker();
-  var dependencies = [];
+  const walker = new Walker();
+  const dependencies = [];
 
   try {
     walker.walk(content, node => {
@@ -54,11 +54,11 @@ function getModulesRequiredFromFilename(filename) {
 }
 
 function checkDirectory(dir, ignoreDirs, deps, devDeps) {
-  var deferred = q.defer();
-  var directoryPromises = [];
-  var finder = walkdir(dir, { "no_recurse": true });
-  var invalidFiles = {};
-  var invalidDirs = {};
+  const deferred = q.defer();
+  const directoryPromises = [];
+  const finder = walkdir(dir, { "no_recurse": true });
+  let invalidFiles = {};
+  const invalidDirs = {};
 
   if (_.isEmpty(deps) && _.isEmpty(devDeps)) {
     finder.emit('end');
@@ -74,7 +74,7 @@ function checkDirectory(dir, ignoreDirs, deps, devDeps) {
 
   finder.on("file", filename => {
     if (path.extname(filename) === ".js") {
-      var modulesRequired = getModulesRequiredFromFilename(filename);
+      let modulesRequired = getModulesRequiredFromFilename(filename);
       if (util.isError(modulesRequired)) {
         invalidFiles[filename] = modulesRequired;
       } else {
@@ -96,8 +96,8 @@ function checkDirectory(dir, ignoreDirs, deps, devDeps) {
           deps = _.intersection(deps, result.value.dependencies);
           devDeps = _.intersection(devDeps, result.value.devDependencies);
         } else {
-          var dirPath = result.reason.dirPath;
-          var error = result.reason.error;
+          const dirPath = result.reason.dirPath;
+          const error = result.reason.error;
           invalidDirs[dirPath] = error;
         }
       });
@@ -129,7 +129,7 @@ function isIgnored(ignoreMatches, dependency) {
 
 function hasBin(rootDir, dependency) {
   try {
-    var depPkg = require(path.join(rootDir, "node_modules", dependency, "package.json"));
+    const depPkg = require(path.join(rootDir, "node_modules", dependency, "package.json"));
     return _.has(depPkg, 'bin');
   } catch (e) {
     return false;
@@ -146,11 +146,11 @@ function filterDependencies(rootDir, ignoreMatches, dependencies) {
 
 function depCheck(rootDir, options, cb) {
 
-  var pkg = options.package || require(path.join(rootDir, 'package.json'));
-  var deps = filterDependencies(rootDir, options.ignoreMatches, pkg.dependencies);
-  var devDeps = filterDependencies(rootDir, options.ignoreMatches, options.withoutDev ? [] : pkg.devDependencies);
+  const pkg = options.package || require(path.join(rootDir, 'package.json'));
+  const deps = filterDependencies(rootDir, options.ignoreMatches, pkg.dependencies);
+  const devDeps = filterDependencies(rootDir, options.ignoreMatches, options.withoutDev ? [] : pkg.devDependencies);
 
-  var ignoreDirs =
+  const ignoreDirs =
     _([
       '.git',
       '.svn',

--- a/src/index.js
+++ b/src/index.js
@@ -126,7 +126,9 @@ function depCheck(rootDir, options, cb) {
   var pkg = options.package || require(path.join(rootDir, 'package.json'));
   var deps = filterDependencies(pkg.dependencies);
   var devDeps = filterDependencies(options.withoutDev ? [] : pkg.devDependencies);
-  var ignoreDirs = _([
+
+  var ignoreDirs =
+    _([
       '.git',
       '.svn',
       '.hg',

--- a/test/fake_modules/bad/index.js
+++ b/test/fake_modules/bad/index.js
@@ -1,1 +1,1 @@
-console.log("I'm bad!");
+log("I'm bad!");

--- a/test/fake_modules/bad_deep/test/sandbox/index.js
+++ b/test/fake_modules/bad_deep/test/sandbox/index.js
@@ -1,1 +1,1 @@
-require("module_bad_deep");
+require('module_bad_deep');

--- a/test/fake_modules/bad_es6/index.js
+++ b/test/fake_modules/bad_es6/index.js
@@ -7,7 +7,7 @@ import name from "name-import";
 import * as star from "star-import";
 import { member } from "member-import";
 import { foobar as barfoo } from "member-alias-import";
-import { foo , bar } from "multiple-member-import";
+import { foo, bar } from "multiple-member-import";
 import { a, b as c } from "mixed-member-alias-import";
 import d, { e } from "mixed-name-memeber-import";
 import h, * as i from "mixed-default-star-import";

--- a/test/fake_modules/bad_es6/index.js
+++ b/test/fake_modules/bad_es6/index.js
@@ -1,7 +1,10 @@
+/* eslint-disable no-unused-vars */
+
 /**
  * This should cover all styles of ES6 imports as described by:
  * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import
  */
+
 import "find-me";
 import name from "name-import";
 import * as star from "star-import";

--- a/test/fake_modules/bad_es6/index.js
+++ b/test/fake_modules/bad_es6/index.js
@@ -5,13 +5,13 @@
  * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import
  */
 
-import "find-me";
-import name from "name-import";
-import * as star from "star-import";
-import { member } from "member-import";
-import { foobar as barfoo } from "member-alias-import";
-import { foo, bar } from "multiple-member-import";
-import { a, b as c } from "mixed-member-alias-import";
-import d, { e } from "mixed-name-memeber-import";
-import h, * as i from "mixed-default-star-import";
-import j from "default-member-import";
+import 'find-me';
+import name from 'name-import';
+import * as star from 'star-import';
+import { member } from 'member-import';
+import { foobar as barfoo } from 'member-alias-import';
+import { foo, bar } from 'multiple-member-import';
+import { a, b as c } from 'mixed-member-alias-import';
+import d, { e } from 'mixed-name-memeber-import';
+import h, * as i from 'mixed-default-star-import';
+import j from 'default-member-import';

--- a/test/fake_modules/bad_js/index.js
+++ b/test/fake_modules/bad_js/index.js
@@ -1,7 +1,7 @@
 
 // there's a ) missing which will make it impossible parse
-;["util","assert"].forEach(function (thing) {
-  thing = require("thing")
+;['util','assert'].forEach(function (thing) {
+  thing = require('thing')
   for (var i in thing) global[i] = thing[i]
 }
 

--- a/test/fake_modules/bin_js/index.js
+++ b/test/fake_modules/bin_js/index.js
@@ -1,1 +1,1 @@
-console.log('The dependency providing `bin` is ignored.');
+log('The dependency providing `bin` is ignored.');

--- a/test/fake_modules/dev/index.js
+++ b/test/fake_modules/dev/index.js
@@ -1,1 +1,3 @@
+/* eslint-disable no-unused-vars */
+
 var optimist = require("optimist");

--- a/test/fake_modules/dev/index.js
+++ b/test/fake_modules/dev/index.js
@@ -1,3 +1,3 @@
 /* eslint-disable no-unused-vars */
 
-const optimist = require("optimist");
+const optimist = require('optimist');

--- a/test/fake_modules/dev/index.js
+++ b/test/fake_modules/dev/index.js
@@ -1,3 +1,3 @@
 /* eslint-disable no-unused-vars */
 
-var optimist = require("optimist");
+const optimist = require("optimist");

--- a/test/fake_modules/empty_dep/index.js
+++ b/test/fake_modules/empty_dep/index.js
@@ -1,1 +1,1 @@
-console.log("I have no dependencies :-(");
+log("I have no dependencies :-(");

--- a/test/fake_modules/empty_dep/index.js
+++ b/test/fake_modules/empty_dep/index.js
@@ -1,1 +1,1 @@
-log("I have no dependencies :-(");
+log('I have no dependencies :-(');

--- a/test/fake_modules/good/index.js
+++ b/test/fake_modules/good/index.js
@@ -1,1 +1,3 @@
+/* eslint-disable no-unused-vars */
+
 var optimist = require("optimist");

--- a/test/fake_modules/good/index.js
+++ b/test/fake_modules/good/index.js
@@ -1,3 +1,3 @@
 /* eslint-disable no-unused-vars */
 
-const optimist = require("optimist");
+const optimist = require('optimist');

--- a/test/fake_modules/good/index.js
+++ b/test/fake_modules/good/index.js
@@ -1,3 +1,3 @@
 /* eslint-disable no-unused-vars */
 
-var optimist = require("optimist");
+const optimist = require("optimist");

--- a/test/fake_modules/good_es6/index.js
+++ b/test/fake_modules/good_es6/index.js
@@ -5,20 +5,20 @@
  * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import
  */
 
-import "basic-import";
-import name from "name-import";
-import * as star from "star-import";
-import { member } from "member-import";
-import { foobar as barfoo } from "member-alias-import";
-import { foo, bar } from "multiple-member-import";
-import { a, b as c } from "mixed-member-alias-import";
-import d, { e } from "mixed-name-memeber-import";
-import h, * as i from "mixed-default-star-import";
-import j from "default-member-import";
+import 'basic-import';
+import name from 'name-import';
+import * as star from 'star-import';
+import { member } from 'member-import';
+import { foobar as barfoo } from 'member-alias-import';
+import { foo, bar } from 'multiple-member-import';
+import { a, b as c } from 'mixed-member-alias-import';
+import d, { e } from 'mixed-name-memeber-import';
+import h, * as i from 'mixed-default-star-import';
+import j from 'default-member-import';
 
-// import "unsupportedSyntax" as seeBelow;
+// import 'unsupportedSyntax' as seeBelow;
 /*
- * The import syntax shown on MDN as `import "module-name" as name;` is
+ * The import syntax shown on MDN as `import 'module-name' as name;` is
  * currently unsupported.
  *
  * This is due to it being unsupported by the JavaScript parsing libraries that

--- a/test/fake_modules/good_es6/index.js
+++ b/test/fake_modules/good_es6/index.js
@@ -7,7 +7,7 @@ import name from "name-import";
 import * as star from "star-import";
 import { member } from "member-import";
 import { foobar as barfoo } from "member-alias-import";
-import { foo , bar } from "multiple-member-import";
+import { foo, bar } from "multiple-member-import";
 import { a, b as c } from "mixed-member-alias-import";
 import d, { e } from "mixed-name-memeber-import";
 import h, * as i from "mixed-default-star-import";

--- a/test/fake_modules/good_es6/index.js
+++ b/test/fake_modules/good_es6/index.js
@@ -1,7 +1,10 @@
+/* eslint-disable no-unused-vars */
+
 /**
  * This should cover (nearly) all ES6 import syntaxes as described by:
  * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import
  */
+
 import "basic-import";
 import name from "name-import";
 import * as star from "star-import";

--- a/test/fake_modules/nested/index.js
+++ b/test/fake_modules/nested/index.js
@@ -1,3 +1,3 @@
 /* eslint-disable no-unused-vars */
 
-var pkg = require("optimist/package.json");
+const pkg = require("optimist/package.json");

--- a/test/fake_modules/nested/index.js
+++ b/test/fake_modules/nested/index.js
@@ -1,1 +1,3 @@
+/* eslint-disable no-unused-vars */
+
 var pkg = require("optimist/package.json");

--- a/test/fake_modules/nested/index.js
+++ b/test/fake_modules/nested/index.js
@@ -1,3 +1,3 @@
 /* eslint-disable no-unused-vars */
 
-const pkg = require("optimist/package.json");
+const pkg = require('optimist/package.json');

--- a/test/index.js
+++ b/test/index.js
@@ -7,8 +7,8 @@ import path from "path";
 import q from 'q';
 
 function asyncTo(fn) {
-  var args = Array.prototype.slice.call(arguments, 1);
-  var defer = q.defer();
+  const args = Array.prototype.slice.call(arguments, 1);
+  const defer = q.defer();
 
   function callback(error, data) {
     if (error) {
@@ -26,7 +26,7 @@ function asyncTo(fn) {
 
 describe("depcheck", () => {
   it("should find unused dependencies", function testUnused(done) {
-    var absolutePath = path.resolve("test/fake_modules/bad");
+    const absolutePath = path.resolve("test/fake_modules/bad");
 
     depcheck(absolutePath, { "withoutDev": true }, function checked(unused) {
       assert.equal(unused.dependencies.length, 1);
@@ -35,7 +35,7 @@ describe("depcheck", () => {
   });
 
   it("should find unused dependencies in ES6 files", function testUnused(done) {
-    var absolutePath = path.resolve("test/fake_modules/bad_es6");
+    const absolutePath = path.resolve("test/fake_modules/bad_es6");
 
     depcheck(absolutePath, { "withoutDev": true }, function checked(unused) {
       assert.equal(unused.dependencies.length, 1);
@@ -45,7 +45,7 @@ describe("depcheck", () => {
   });
 
   it("should find all dependencies", function testUnused(done) {
-    var absolutePath = path.resolve("test/fake_modules/good");
+    const absolutePath = path.resolve("test/fake_modules/good");
 
     depcheck(absolutePath, { "withoutDev": true }, function checked(unused) {
       assert.equal(unused.dependencies.length, 0);
@@ -54,7 +54,7 @@ describe("depcheck", () => {
   });
 
   it("should find all dependencies in ES6 files", function testUnused(done) {
-    var absolutePath = path.resolve("test/fake_modules/good_es6");
+    const absolutePath = path.resolve("test/fake_modules/good_es6");
 
     depcheck(absolutePath, { "withoutDev": true }, function checked(unused) {
       // See ./good_es6/index.js for more information on the unsupported ES6
@@ -66,7 +66,7 @@ describe("depcheck", () => {
   });
 
   it("should find manage grunt dependencies", function testUnused(done) {
-    var absolutePath = path.resolve("test/fake_modules/grunt");
+    const absolutePath = path.resolve("test/fake_modules/grunt");
 
     depcheck(absolutePath, { "withoutDev": true }, function checked(unused) {
       assert.equal(unused.dependencies.length, 0);
@@ -75,7 +75,7 @@ describe("depcheck", () => {
   });
 
   it("should find manage grunt task dependencies", function testUnused(done) {
-    var absolutePath = path.resolve("test/fake_modules/grunt-tasks");
+    const absolutePath = path.resolve("test/fake_modules/grunt-tasks");
 
     depcheck(absolutePath, { "withoutDev": true }, function checked(unused) {
       assert.equal(unused.dependencies.length, 0);
@@ -84,7 +84,7 @@ describe("depcheck", () => {
   });
 
   it("should look at devDependencies", function testUnused(done) {
-    var absolutePath = path.resolve("test/fake_modules/dev");
+    const absolutePath = path.resolve("test/fake_modules/dev");
 
     depcheck(absolutePath, { "withoutDev": false }, function checked(unused) {
       assert.equal(unused.devDependencies.length, 1);
@@ -93,7 +93,7 @@ describe("depcheck", () => {
   });
 
   it("should ignore ignoreDirs", function testUnused(done) {
-    var absolutePath = path.resolve("test/fake_modules/bad_deep");
+    const absolutePath = path.resolve("test/fake_modules/bad_deep");
 
     depcheck(absolutePath, { "ignoreDirs": ['sandbox'] }, function checked(unused) {
       assert.equal(unused.dependencies.length, 1);
@@ -103,7 +103,7 @@ describe("depcheck", () => {
   });
 
   it("should ignore ignoreMatches", function testUnused(done) {
-    var absolutePath = path.resolve("test/fake_modules/bad");
+    const absolutePath = path.resolve("test/fake_modules/bad");
 
     depcheck(absolutePath, { "ignoreMatches": ['o*'] }, function checked(unused) {
       assert.equal(unused.dependencies.length, 0);
@@ -112,16 +112,16 @@ describe("depcheck", () => {
   });
 
   it("should ignore bad javascript", function testBadJS(done) {
-    var absolutePath = path.resolve("test/fake_modules/bad_js");
+    const absolutePath = path.resolve("test/fake_modules/bad_js");
 
     depcheck(absolutePath, {  }, function checked(unused) {
       unused.dependencies.should.have.length(1);
 
-      var invalidFiles = Object.keys(unused.invalidFiles);
+      const invalidFiles = Object.keys(unused.invalidFiles);
       invalidFiles.should.have.length(1);
       invalidFiles[0].should.endWith('/test/fake_modules/bad_js/index.js');
 
-      var error = unused.invalidFiles[invalidFiles[0]];
+      const error = unused.invalidFiles[invalidFiles[0]];
       error.should.be.instanceof(SyntaxError);
 
       done();
@@ -129,7 +129,7 @@ describe("depcheck", () => {
   });
 
   it("should recognize nested requires", function testNested(done) {
-    var absolutePath = path.resolve("test/fake_modules/nested");
+    const absolutePath = path.resolve("test/fake_modules/nested");
 
     depcheck(absolutePath, {  }, function checked(unused) {
       assert.equal(unused.dependencies.length, 0);
@@ -138,7 +138,7 @@ describe("depcheck", () => {
   });
 
   it("should support module names that are numbers", function testNested(done) {
-    var absolutePath = path.resolve("test/fake_modules/number");
+    const absolutePath = path.resolve("test/fake_modules/number");
 
     depcheck(absolutePath, {  }, function checked(unused) {
       assert.equal(unused.dependencies.length, 0);
@@ -147,7 +147,7 @@ describe("depcheck", () => {
   });
 
   it("should handle empty JavaScript file", function testEmpty(done) {
-    var absolutePath = path.resolve("test/fake_modules/empty_file");
+    const absolutePath = path.resolve("test/fake_modules/empty_file");
 
     depcheck(absolutePath, {}, function checked(unused) {
       assert.equal(unused.dependencies.length, 1);
@@ -156,7 +156,7 @@ describe("depcheck", () => {
   });
 
   it("should allow dynamic package metadata", function testDynamic(done) {
-    var absolutePath = path.resolve("test/fake_modules/bad");
+    const absolutePath = path.resolve("test/fake_modules/bad");
 
     depcheck(absolutePath, {
       "package": {
@@ -172,7 +172,7 @@ describe("depcheck", () => {
   });
 
   it("should exclude bin dependencies", function testBin(done) {
-    var absolutePath = path.resolve("test/fake_modules/bin_js");
+    const absolutePath = path.resolve("test/fake_modules/bin_js");
 
     depcheck(absolutePath, {  }, function checked(unused) {
       assert.equal(unused.dependencies.length, 0);
@@ -181,19 +181,19 @@ describe("depcheck", () => {
   });
 
   it('should handle directory access error', function testNonReadable() {
-    var absolutePath = path.resolve("test/fake_modules/bad");
-    var unreadableDir = path.join(absolutePath, 'unreadable');
+    const absolutePath = path.resolve("test/fake_modules/bad");
+    const unreadableDir = path.join(absolutePath, 'unreadable');
 
     return asyncTo(fs.mkdir, unreadableDir, '0000')()
       .then(asyncTo(depcheck, absolutePath, {}))
       .catch(function checked(unused) {
         unused.dependencies.should.have.length(1);
 
-        var invalidDirs = Object.keys(unused.invalidDirs);
+        const invalidDirs = Object.keys(unused.invalidDirs);
         invalidDirs.should.have.length(1);
         invalidDirs[0].should.endWith('/test/fake_modules/bad/unreadable');
 
-        var error = unused.invalidDirs[invalidDirs[0]];
+        const error = unused.invalidDirs[invalidDirs[0]];
         error.should.be.instanceof(Error);
         error.toString().should.containEql('EACCES');
       })
@@ -202,7 +202,7 @@ describe("depcheck", () => {
   });
 
   it("should work without dependencies", function testNoDependencies(done) {
-    var absolutePath = path.resolve("test/fake_modules/empty_dep");
+    const absolutePath = path.resolve("test/fake_modules/empty_dep");
 
     depcheck(absolutePath, {  }, function checked(unused) {
       assert.equal(unused.dependencies.length, 0);
@@ -211,7 +211,7 @@ describe("depcheck", () => {
   });
 
   it('should handle require function with parameterless', function testRequireNothing() {
-    var absolutePath = path.resolve("test/fake_modules/require_nothing");
+    const absolutePath = path.resolve("test/fake_modules/require_nothing");
 
     depcheck(absolutePath, {  }, function checked(unused) {
       assert.equal(unused.dependencies.length, 1);

--- a/test/index.js
+++ b/test/index.js
@@ -18,13 +18,13 @@ function asyncTo(fn) {
     }
   }
 
-  return function () {
+  return () => {
     fn.apply(null, args.concat(callback));
     return defer.promise;
   }
 }
 
-describe("depcheck", function () {
+describe("depcheck", () => {
   it("should find unused dependencies", function testUnused(done) {
     var absolutePath = path.resolve("test/fake_modules/bad");
 

--- a/test/index.js
+++ b/test/index.js
@@ -21,7 +21,7 @@ function asyncTo(fn) {
   return () => {
     fn.apply(null, args.concat(callback));
     return defer.promise;
-  }
+  };
 }
 
 describe('depcheck', () => {

--- a/test/index.js
+++ b/test/index.js
@@ -1,9 +1,9 @@
 /* global describe, it */
 
-import assert from "should";
-import depcheck from "../src/index";
-import fs from "fs";
-import path from "path";
+import assert from 'should';
+import depcheck from '../src/index';
+import fs from 'fs';
+import path from 'path';
 import q from 'q';
 
 function asyncTo(fn) {
@@ -24,95 +24,95 @@ function asyncTo(fn) {
   }
 }
 
-describe("depcheck", () => {
-  it("should find unused dependencies", function testUnused(done) {
-    const absolutePath = path.resolve("test/fake_modules/bad");
+describe('depcheck', () => {
+  it('should find unused dependencies', function testUnused(done) {
+    const absolutePath = path.resolve('test/fake_modules/bad');
 
-    depcheck(absolutePath, { "withoutDev": true }, function checked(unused) {
+    depcheck(absolutePath, { 'withoutDev': true }, function checked(unused) {
       assert.equal(unused.dependencies.length, 1);
       done();
     });
   });
 
-  it("should find unused dependencies in ES6 files", function testUnused(done) {
-    const absolutePath = path.resolve("test/fake_modules/bad_es6");
+  it('should find unused dependencies in ES6 files', function testUnused(done) {
+    const absolutePath = path.resolve('test/fake_modules/bad_es6');
 
-    depcheck(absolutePath, { "withoutDev": true }, function checked(unused) {
+    depcheck(absolutePath, { 'withoutDev': true }, function checked(unused) {
       assert.equal(unused.dependencies.length, 1);
-      assert.equal(unused.dependencies[0], "dont-find-me");
+      assert.equal(unused.dependencies[0], 'dont-find-me');
       done();
     });
   });
 
-  it("should find all dependencies", function testUnused(done) {
-    const absolutePath = path.resolve("test/fake_modules/good");
+  it('should find all dependencies', function testUnused(done) {
+    const absolutePath = path.resolve('test/fake_modules/good');
 
-    depcheck(absolutePath, { "withoutDev": true }, function checked(unused) {
+    depcheck(absolutePath, { 'withoutDev': true }, function checked(unused) {
       assert.equal(unused.dependencies.length, 0);
       done();
     });
   });
 
-  it("should find all dependencies in ES6 files", function testUnused(done) {
-    const absolutePath = path.resolve("test/fake_modules/good_es6");
+  it('should find all dependencies in ES6 files', function testUnused(done) {
+    const absolutePath = path.resolve('test/fake_modules/good_es6');
 
-    depcheck(absolutePath, { "withoutDev": true }, function checked(unused) {
+    depcheck(absolutePath, { 'withoutDev': true }, function checked(unused) {
       // See ./good_es6/index.js for more information on the unsupported ES6
       // import syntax, which we assert here as the expected missing import.
       assert.equal(unused.dependencies.length, 1);
-      assert.equal(unused.dependencies[0], "unsupported-syntax");
+      assert.equal(unused.dependencies[0], 'unsupported-syntax');
       done();
     });
   });
 
-  it("should find manage grunt dependencies", function testUnused(done) {
-    const absolutePath = path.resolve("test/fake_modules/grunt");
+  it('should find manage grunt dependencies', function testUnused(done) {
+    const absolutePath = path.resolve('test/fake_modules/grunt');
 
-    depcheck(absolutePath, { "withoutDev": true }, function checked(unused) {
+    depcheck(absolutePath, { 'withoutDev': true }, function checked(unused) {
       assert.equal(unused.dependencies.length, 0);
       done();
     });
   });
 
-  it("should find manage grunt task dependencies", function testUnused(done) {
-    const absolutePath = path.resolve("test/fake_modules/grunt-tasks");
+  it('should find manage grunt task dependencies', function testUnused(done) {
+    const absolutePath = path.resolve('test/fake_modules/grunt-tasks');
 
-    depcheck(absolutePath, { "withoutDev": true }, function checked(unused) {
+    depcheck(absolutePath, { 'withoutDev': true }, function checked(unused) {
       assert.equal(unused.dependencies.length, 0);
       done();
     });
   });
 
-  it("should look at devDependencies", function testUnused(done) {
-    const absolutePath = path.resolve("test/fake_modules/dev");
+  it('should look at devDependencies', function testUnused(done) {
+    const absolutePath = path.resolve('test/fake_modules/dev');
 
-    depcheck(absolutePath, { "withoutDev": false }, function checked(unused) {
+    depcheck(absolutePath, { 'withoutDev': false }, function checked(unused) {
       assert.equal(unused.devDependencies.length, 1);
       done();
     });
   });
 
-  it("should ignore ignoreDirs", function testUnused(done) {
-    const absolutePath = path.resolve("test/fake_modules/bad_deep");
+  it('should ignore ignoreDirs', function testUnused(done) {
+    const absolutePath = path.resolve('test/fake_modules/bad_deep');
 
-    depcheck(absolutePath, { "ignoreDirs": ['sandbox'] }, function checked(unused) {
+    depcheck(absolutePath, { 'ignoreDirs': ['sandbox'] }, function checked(unused) {
       assert.equal(unused.dependencies.length, 1);
       assert.equal(unused.dependencies[0], 'module_bad_deep');
       done();
     });
   });
 
-  it("should ignore ignoreMatches", function testUnused(done) {
-    const absolutePath = path.resolve("test/fake_modules/bad");
+  it('should ignore ignoreMatches', function testUnused(done) {
+    const absolutePath = path.resolve('test/fake_modules/bad');
 
-    depcheck(absolutePath, { "ignoreMatches": ['o*'] }, function checked(unused) {
+    depcheck(absolutePath, { 'ignoreMatches': ['o*'] }, function checked(unused) {
       assert.equal(unused.dependencies.length, 0);
       done();
     });
   });
 
-  it("should ignore bad javascript", function testBadJS(done) {
-    const absolutePath = path.resolve("test/fake_modules/bad_js");
+  it('should ignore bad javascript', function testBadJS(done) {
+    const absolutePath = path.resolve('test/fake_modules/bad_js');
 
     depcheck(absolutePath, {  }, function checked(unused) {
       unused.dependencies.should.have.length(1);
@@ -128,8 +128,8 @@ describe("depcheck", () => {
     });
   });
 
-  it("should recognize nested requires", function testNested(done) {
-    const absolutePath = path.resolve("test/fake_modules/nested");
+  it('should recognize nested requires', function testNested(done) {
+    const absolutePath = path.resolve('test/fake_modules/nested');
 
     depcheck(absolutePath, {  }, function checked(unused) {
       assert.equal(unused.dependencies.length, 0);
@@ -137,8 +137,8 @@ describe("depcheck", () => {
     });
   });
 
-  it("should support module names that are numbers", function testNested(done) {
-    const absolutePath = path.resolve("test/fake_modules/number");
+  it('should support module names that are numbers', function testNested(done) {
+    const absolutePath = path.resolve('test/fake_modules/number');
 
     depcheck(absolutePath, {  }, function checked(unused) {
       assert.equal(unused.dependencies.length, 0);
@@ -146,8 +146,8 @@ describe("depcheck", () => {
     });
   });
 
-  it("should handle empty JavaScript file", function testEmpty(done) {
-    const absolutePath = path.resolve("test/fake_modules/empty_file");
+  it('should handle empty JavaScript file', function testEmpty(done) {
+    const absolutePath = path.resolve('test/fake_modules/empty_file');
 
     depcheck(absolutePath, {}, function checked(unused) {
       assert.equal(unused.dependencies.length, 1);
@@ -155,14 +155,14 @@ describe("depcheck", () => {
     });
   });
 
-  it("should allow dynamic package metadata", function testDynamic(done) {
-    const absolutePath = path.resolve("test/fake_modules/bad");
+  it('should allow dynamic package metadata', function testDynamic(done) {
+    const absolutePath = path.resolve('test/fake_modules/bad');
 
     depcheck(absolutePath, {
-      "package": {
-        "dependencies": {
-          "optimist": "~0.6.0",
-          "express": "^4.0.0",
+      'package': {
+        'dependencies': {
+          'optimist': '~0.6.0',
+          'express': '^4.0.0',
         },
       },
     }, function checked(unused) {
@@ -171,8 +171,8 @@ describe("depcheck", () => {
     });
   });
 
-  it("should exclude bin dependencies", function testBin(done) {
-    const absolutePath = path.resolve("test/fake_modules/bin_js");
+  it('should exclude bin dependencies', function testBin(done) {
+    const absolutePath = path.resolve('test/fake_modules/bin_js');
 
     depcheck(absolutePath, {  }, function checked(unused) {
       assert.equal(unused.dependencies.length, 0);
@@ -181,7 +181,7 @@ describe("depcheck", () => {
   });
 
   it('should handle directory access error', function testNonReadable() {
-    const absolutePath = path.resolve("test/fake_modules/bad");
+    const absolutePath = path.resolve('test/fake_modules/bad');
     const unreadableDir = path.join(absolutePath, 'unreadable');
 
     return asyncTo(fs.mkdir, unreadableDir, '0000')()
@@ -201,8 +201,8 @@ describe("depcheck", () => {
       .finally(asyncTo(fs.rmdir, unreadableDir));
   });
 
-  it("should work without dependencies", function testNoDependencies(done) {
-    const absolutePath = path.resolve("test/fake_modules/empty_dep");
+  it('should work without dependencies', function testNoDependencies(done) {
+    const absolutePath = path.resolve('test/fake_modules/empty_dep');
 
     depcheck(absolutePath, {  }, function checked(unused) {
       assert.equal(unused.dependencies.length, 0);
@@ -211,7 +211,7 @@ describe("depcheck", () => {
   });
 
   it('should handle require function with parameterless', function testRequireNothing() {
-    const absolutePath = path.resolve("test/fake_modules/require_nothing");
+    const absolutePath = path.resolve('test/fake_modules/require_nothing');
 
     depcheck(absolutePath, {  }, function checked(unused) {
       assert.equal(unused.dependencies.length, 1);

--- a/test/index.js
+++ b/test/index.js
@@ -162,9 +162,9 @@ describe("depcheck", function () {
       "package": {
         "dependencies": {
           "optimist": "~0.6.0",
-          "express": "^4.0.0"
-        }
-      }
+          "express": "^4.0.0",
+        },
+      },
     }, function checked(unused) {
       assert.equal(unused.dependencies.length, 2);
       done();


### PR DESCRIPTION
Reference #10 

Resolve most of the ESLint warnings. There are three two kinds of warnings kept [there](https://travis-ci.org/lijunle/depcheck-es6/jobs/81640699#L154-L163).
- **no-param-reassign**
  
  It needs to modify the code logic.
- **error  Unexpected token**
  
  This is caused by parse error from `test/fake_modules/bad_js/index.js` file. But the syntax error is expected. I do not have an idea to resolve this error. :disappointed: 
- Besides, there are two variables using `let` declaration - `invalidFiles` and `moduleRequired`. We should avoid using `let` declaration and **only** use `const` keyword. However, it requires updating code logic, which is as-is now.
