### PR TITLE
Convert test to data driven

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
   "scripts": {
     "prepublish": "babel src/ -d dist/",
     "lint": "./node_modules/.bin/eslint ./src ./test",
-    "test": "mocha --compilers js:babel/register test/index.js",
-    "test-coverage": "babel-node ./node_modules/.bin/isparta cover node_modules/mocha/bin/_mocha test/index.js",
-    "test-coveralls": "babel-node ./node_modules/.bin/isparta cover node_modules/mocha/bin/_mocha test/index.js --report lcovonly -- -R spec"
+    "test": "mocha --compilers js:babel/register ./test",
+    "test-coverage": "babel-node ./node_modules/.bin/isparta cover node_modules/mocha/bin/_mocha ./test",
+    "test-coveralls": "babel-node ./node_modules/.bin/isparta cover node_modules/mocha/bin/_mocha ./test --report lcovonly -- -R spec"
   },
   "author": [
     "Djordje Lukic",

--- a/test/cli.js
+++ b/test/cli.js
@@ -1,0 +1,45 @@
+/* global describe, it */
+
+import 'should';
+import fs from 'fs';
+import path from 'path';
+import cli from '../src/cli';
+
+function makeArgv(testCase) {
+  const options = testCase.options;
+  const testPath = path.resolve('test/fake_modules/' + testCase.module);
+  const argv = [testPath, '--json'];
+
+  if (options.withoutDev) {
+    argv.push('--dev=false');
+  }
+
+  return argv;
+}
+
+describe('depcheck command line', () => {
+  const spec = fs.readFileSync(__dirname + '/spec.json', { encoding: 'utf8' });
+  const testCases = JSON.parse(spec);
+
+  testCases.forEach(testCase => {
+    it('should ' + testCase.name, () =>
+      new Promise(resolve => {
+        let log;
+
+        cli(
+          makeArgv(testCase),
+          data => log = data,
+          data => data.should.fail(), // should not go into error log
+          exitCode => resolve({ log, exitCode })
+        );
+      }).then(({ log, exitCode }) => {
+        const actual = JSON.parse(log);
+        const expected = testCase.expected;
+
+        actual.dependencies.should.eql(expected.dependencies);
+        actual.devDependencies.should.eql(expected.devDependencies);
+
+        exitCode.should.equal(0); // JSON output always return 0
+      }));
+  });
+});

--- a/test/cli.js
+++ b/test/cli.js
@@ -14,6 +14,10 @@ function makeArgv(testCase) {
     argv.push('--dev=false');
   }
 
+  if (options.ignoreMatches) {
+    argv.push('--ignores=' + options.ignoreMatches.join(','));
+  }
+
   return argv;
 }
 
@@ -22,6 +26,11 @@ describe('depcheck command line', () => {
   const testCases = JSON.parse(spec);
 
   testCases.forEach(testCase => {
+    if (testCase.name === 'ignore ignoreDirs') {
+      // TODO command line not supports ignoreDirs options yet, skip it
+      return true;
+    }
+
     it('should ' + testCase.name, () =>
       new Promise(resolve => {
         let log;

--- a/test/index.js
+++ b/test/index.js
@@ -25,89 +25,20 @@ function asyncTo(fn) {
 }
 
 describe('depcheck', () => {
-  describe('with spec', () => {
-    const spec = fs.readFileSync(__dirname + '/spec.json', { encoding: 'utf8' });
-    const testCases = JSON.parse(spec);
+  const spec = fs.readFileSync(__dirname + '/spec.json', { encoding: 'utf8' });
+  const testCases = JSON.parse(spec);
 
-    testCases.forEach(testCase => {
-      it('should ' + testCase.name, done => {
-        const testPath = path.resolve('test/fake_modules/' + testCase.module);
-        const options = testCase.options;
-        const expected = testCase.expected;
+  testCases.forEach(testCase => {
+    it('should ' + testCase.name, done => {
+      const testPath = path.resolve('test/fake_modules/' + testCase.module);
+      const options = testCase.options;
+      const expected = testCase.expected;
 
-        depcheck(testPath, options, result => {
-          result.dependencies.should.eql(expected.dependencies);
-          result.devDependencies.should.eql(expected.devDependencies);
-          done();
-        });
+      depcheck(testPath, options, result => {
+        result.dependencies.should.eql(expected.dependencies);
+        result.devDependencies.should.eql(expected.devDependencies);
+        done();
       });
-    });
-  });
-
-  it('should find unused dependencies', function testUnused(done) {
-    const absolutePath = path.resolve('test/fake_modules/bad');
-
-    depcheck(absolutePath, { 'withoutDev': true }, function checked(unused) {
-      assert.equal(unused.dependencies.length, 1);
-      done();
-    });
-  });
-
-  it('should find unused dependencies in ES6 files', function testUnused(done) {
-    const absolutePath = path.resolve('test/fake_modules/bad_es6');
-
-    depcheck(absolutePath, { 'withoutDev': true }, function checked(unused) {
-      assert.equal(unused.dependencies.length, 1);
-      assert.equal(unused.dependencies[0], 'dont-find-me');
-      done();
-    });
-  });
-
-  it('should find all dependencies', function testUnused(done) {
-    const absolutePath = path.resolve('test/fake_modules/good');
-
-    depcheck(absolutePath, { 'withoutDev': true }, function checked(unused) {
-      assert.equal(unused.dependencies.length, 0);
-      done();
-    });
-  });
-
-  it('should find all dependencies in ES6 files', function testUnused(done) {
-    const absolutePath = path.resolve('test/fake_modules/good_es6');
-
-    depcheck(absolutePath, { 'withoutDev': true }, function checked(unused) {
-      // See ./good_es6/index.js for more information on the unsupported ES6
-      // import syntax, which we assert here as the expected missing import.
-      assert.equal(unused.dependencies.length, 1);
-      assert.equal(unused.dependencies[0], 'unsupported-syntax');
-      done();
-    });
-  });
-
-  it('should find manage grunt dependencies', function testUnused(done) {
-    const absolutePath = path.resolve('test/fake_modules/grunt');
-
-    depcheck(absolutePath, { 'withoutDev': true }, function checked(unused) {
-      assert.equal(unused.dependencies.length, 0);
-      done();
-    });
-  });
-
-  it('should find manage grunt task dependencies', function testUnused(done) {
-    const absolutePath = path.resolve('test/fake_modules/grunt-tasks');
-
-    depcheck(absolutePath, { 'withoutDev': true }, function checked(unused) {
-      assert.equal(unused.dependencies.length, 0);
-      done();
-    });
-  });
-
-  it('should look at devDependencies', function testUnused(done) {
-    const absolutePath = path.resolve('test/fake_modules/dev');
-
-    depcheck(absolutePath, { 'withoutDev': false }, function checked(unused) {
-      assert.equal(unused.devDependencies.length, 1);
-      done();
     });
   });
 
@@ -147,33 +78,6 @@ describe('depcheck', () => {
     });
   });
 
-  it('should recognize nested requires', function testNested(done) {
-    const absolutePath = path.resolve('test/fake_modules/nested');
-
-    depcheck(absolutePath, {  }, function checked(unused) {
-      assert.equal(unused.dependencies.length, 0);
-      done();
-    });
-  });
-
-  it('should support module names that are numbers', function testNested(done) {
-    const absolutePath = path.resolve('test/fake_modules/number');
-
-    depcheck(absolutePath, {  }, function checked(unused) {
-      assert.equal(unused.dependencies.length, 0);
-      done();
-    });
-  });
-
-  it('should handle empty JavaScript file', function testEmpty(done) {
-    const absolutePath = path.resolve('test/fake_modules/empty_file');
-
-    depcheck(absolutePath, {}, function checked(unused) {
-      assert.equal(unused.dependencies.length, 1);
-      done();
-    });
-  });
-
   it('should allow dynamic package metadata', function testDynamic(done) {
     const absolutePath = path.resolve('test/fake_modules/bad');
 
@@ -186,15 +90,6 @@ describe('depcheck', () => {
       },
     }, function checked(unused) {
       assert.equal(unused.dependencies.length, 2);
-      done();
-    });
-  });
-
-  it('should exclude bin dependencies', function testBin(done) {
-    const absolutePath = path.resolve('test/fake_modules/bin_js');
-
-    depcheck(absolutePath, {  }, function checked(unused) {
-      assert.equal(unused.dependencies.length, 0);
       done();
     });
   });
@@ -218,24 +113,5 @@ describe('depcheck', () => {
       })
       .finally(asyncTo(fs.chmod, unreadableDir, '0700'))
       .finally(asyncTo(fs.rmdir, unreadableDir));
-  });
-
-  it('should work without dependencies', function testNoDependencies(done) {
-    const absolutePath = path.resolve('test/fake_modules/empty_dep');
-
-    depcheck(absolutePath, {  }, function checked(unused) {
-      assert.equal(unused.dependencies.length, 0);
-      done();
-    });
-  });
-
-  it('should handle require function with parameterless', function testRequireNothing(done) {
-    const absolutePath = path.resolve('test/fake_modules/require_nothing');
-
-    depcheck(absolutePath, {  }, function checked(unused) {
-      assert.equal(unused.dependencies.length, 1);
-      assert.equal(unused.dependencies[0], 'require-nothing');
-      done();
-    });
   });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -42,25 +42,6 @@ describe('depcheck', () => {
     });
   });
 
-  it('should ignore ignoreDirs', function testUnused(done) {
-    const absolutePath = path.resolve('test/fake_modules/bad_deep');
-
-    depcheck(absolutePath, { 'ignoreDirs': ['sandbox'] }, function checked(unused) {
-      assert.equal(unused.dependencies.length, 1);
-      assert.equal(unused.dependencies[0], 'module_bad_deep');
-      done();
-    });
-  });
-
-  it('should ignore ignoreMatches', function testUnused(done) {
-    const absolutePath = path.resolve('test/fake_modules/bad');
-
-    depcheck(absolutePath, { 'ignoreMatches': ['o*'] }, function checked(unused) {
-      assert.equal(unused.dependencies.length, 0);
-      done();
-    });
-  });
-
   it('should ignore bad javascript', function testBadJS(done) {
     const absolutePath = path.resolve('test/fake_modules/bad_js');
 

--- a/test/index.js
+++ b/test/index.js
@@ -25,6 +25,25 @@ function asyncTo(fn) {
 }
 
 describe('depcheck', () => {
+  describe('with spec', () => {
+    const spec = fs.readFileSync(__dirname + '/spec.json', { encoding: 'utf8' });
+    const testCases = JSON.parse(spec);
+
+    testCases.forEach(testCase => {
+      it('should ' + testCase.name, done => {
+        const testPath = path.resolve('test/fake_modules/' + testCase.module);
+        const options = testCase.options;
+        const expected = testCase.expected;
+
+        depcheck(testPath, options, result => {
+          result.dependencies.should.eql(expected.dependencies);
+          result.devDependencies.should.eql(expected.devDependencies);
+          done();
+        });
+      });
+    });
+  });
+
   it('should find unused dependencies', function testUnused(done) {
     const absolutePath = path.resolve('test/fake_modules/bad');
 

--- a/test/spec.json
+++ b/test/spec.json
@@ -1,0 +1,13 @@
+[
+  {
+    "name": "find unused dependencies",
+    "module": "bad",
+    "options": {
+      "withoutDev": true
+    },
+    "expected": {
+      "dependencies": ["optimist"],
+      "devDependencies": []
+    }
+  }
+]

--- a/test/spec.json
+++ b/test/spec.json
@@ -136,5 +136,27 @@
       "dependencies": ["require-nothing"],
       "devDependencies": []
     }
+  },
+  {
+    "name": "ignore ignoreDirs",
+    "module": "bad_deep",
+    "options": {
+      "ignoreDirs": ["sandbox"]
+    },
+    "expected": {
+      "dependencies": ["module_bad_deep"],
+      "devDependencies": []
+    }
+  },
+  {
+    "name": "ignore ignoreMatches",
+    "module": "bad",
+    "options": {
+      "ignoreMatches": ["o*"]
+    },
+    "expected": {
+      "dependencies": [],
+      "devDependencies": []
+    }
   }
 ]

--- a/test/spec.json
+++ b/test/spec.json
@@ -9,5 +9,132 @@
       "dependencies": ["optimist"],
       "devDependencies": []
     }
+  },
+  {
+    "name": "find unused dependencies in ES6 files",
+    "module": "bad_es6",
+    "options": {
+      "withoutDev": true
+    },
+    "expected": {
+      "dependencies": ["dont-find-me"],
+      "devDependencies": []
+    }
+  },
+  {
+    "name": "find all dependencies",
+    "module": "good",
+    "options": {
+      "withoutDev": true
+    },
+    "expected": {
+      "dependencies": [],
+      "devDependencies": []
+    }
+  },
+  {
+    "name": "find all dependencies in ES6 files",
+    "module": "good_es6",
+    "options": {
+      "withoutDev": true
+    },
+    "expected": {
+      "dependencies": ["unsupported-syntax"],
+      "devDependencies": []
+    },
+    "notice": "See `good_es6/index.js` file for more information on the unsupported ES6 import syntax, which we assert here as the expected missing import."
+  },
+  {
+    "name": "find grunt dependencies",
+    "module": "grunt",
+    "options": {
+      "withoutDev": true
+    },
+    "expected": {
+      "dependencies": [],
+      "devDependencies": []
+    }
+  },
+  {
+    "name": "find grunt task dependencies",
+    "module": "grunt-tasks",
+    "options": {
+      "withoutDev": true
+    },
+    "expected": {
+      "dependencies": [],
+      "devDependencies": []
+    }
+  },
+  {
+    "name": "find unused package in devDependencies",
+    "module": "dev",
+    "options": {
+      "withoutDev": false
+    },
+    "expected": {
+      "dependencies": [],
+      "devDependencies": ["mocha"]
+    }
+  },
+  {
+    "name": "recognize nested requires",
+    "module": "nested",
+    "options": {
+    },
+    "expected": {
+      "dependencies": [],
+      "devDependencies": []
+    }
+  },
+  {
+    "name": "support module names that are numbers",
+    "module": "number",
+    "options": {
+    },
+    "expected": {
+      "dependencies": [],
+      "devDependencies": []
+    }
+  },
+  {
+    "name": "handle empty JavaScript file",
+    "module": "empty_file",
+    "options": {
+    },
+    "expected": {
+      "dependencies": ["empty-package"],
+      "devDependencies": []
+    }
+  },
+  {
+    "name": "handle a package without any dependencies",
+    "module": "empty_dep",
+    "options": {
+    },
+    "expected": {
+      "dependencies": [],
+      "devDependencies": []
+    }
+  },
+  {
+    "name": "exclude bin dependencies",
+    "module": "bin_js",
+    "options": {
+    },
+    "expected": {
+      "dependencies": [],
+      "devDependencies": []
+    }
+  },
+  {
+    "name": "handle require call without parameters",
+    "module": "require_nothing",
+    "options": {
+    },
+    "expected": {
+      "dependencies": ["require-nothing"],
+      "devDependencies": []
+    }
   }
 ]


### PR DESCRIPTION
- Cover `cli.js` binary script, coverage rate is not good enough.
- Avoid test case boiler-plate, resolve #17 
