### PR TITLE
Make cli.js unit-testable.

### DIFF
--- a/bin/depcheck
+++ b/bin/depcheck
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+/* eslint-disable no-console */
+
+require('../dist/cli')(console.log, console.error, process.exit);

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Check dependencies in your node module",
   "main": "dist/index.js",
   "bin": {
-    "depcheck": "dist/cli.js"
+    "depcheck": "bin/depcheck"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
- Make `console.log` and `process.exit` functions passed as parameters.
- Add simple wrapper `bin/depcheck` as package binary entry.
