### PR TITLE
Fix invalidDir bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,6 +93,7 @@ function checkDirectory(dir, ignoreDirs, deps, devDeps) {
       _.each(directoryResults, function(result) {
         if (result.state === 'fulfilled') {
           invalidFiles = _.merge(invalidFiles, result.value.invalidFiles, {});
+          invalidDirs = _.merge(invalidDirs, result.value.invalidDirs, {});
           deps = _.intersection(deps, result.value.dependencies);
           devDeps = _.intersection(devDeps, result.value.devDependencies);
         } else {
@@ -112,10 +113,10 @@ function checkDirectory(dir, ignoreDirs, deps, devDeps) {
   });
 
   finder.on("error", function (path, err) {
-    deferred.reject({
+    directoryPromises.push(q.reject({
       path: path,
       error: err
-    });
+    }));
   });
 
   return deferred.promise;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "depcheck-es6",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Check dependencies in your node module",
   "main": "index",
   "bin": {

--- a/test/fake_modules/unreadable_deep/deep/nested/index.js
+++ b/test/fake_modules/unreadable_deep/deep/nested/index.js
@@ -1,0 +1,1 @@
+require('unreadable-deep');

--- a/test/fake_modules/unreadable_deep/package.json
+++ b/test/fake_modules/unreadable_deep/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "unreadable-deep": "0.0.1"
+  }
+}

--- a/test/index.js
+++ b/test/index.js
@@ -210,7 +210,7 @@ describe("depcheck", function () {
     });
   });
 
-  it('should handle require function with parameterless', function testRequireNothing() {
+  it('should handle require function with parameterless', function testRequireNothing(done) {
     var absolutePath = path.resolve("test/fake_modules/require_nothing");
 
     depcheck(absolutePath, {  }, function checked(unused) {


### PR DESCRIPTION
- **This fix has been [tagged](https://github.com/lijunle/depcheck-es6/tree/0.5.2) and [released](https://www.npmjs.com/package/depcheck-es6) as `0.5.2`, port the fix to master**
- When invalidDirs happens, it throws other useful information away and reject promise directly. This is wrong.
- It should add the rejected promise to queue and handle all information at the end of finder's end.
