### PR TITLE
Refactor Code and Implement Pluggable Design

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "minimatch": "^2.0.1",
     "node-source-walk": "^2.0.0",
     "optimist": "~0.6.0",
-    "q": "^1.0.1",
     "walkdir": "0.0.7"
   },
   "devDependencies": {


### PR DESCRIPTION
- Refactor the main walkdir logic.
- Implement the pluggable design (resolve #27)
- Remove `q` dependencies, use babel provided promise
- Convert _sync_ function async pattern (resolve #11)

TODO:
- Add unit test for customized parsers and detectors
