### PR TITLE
Add more test cases

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -158,7 +158,6 @@ function filterDependencies(rootDir, ignoreMatches, dependencies) {
 }
 
 function depCheck(rootDir, options, cb) {
-  // TODO test pass parsers and detectors from options
   const parsers = options.parsers || defaultOptions.parsers;
   const detectors = options.detectors || defaultOptions.detectors;
   const ignoreMatches = options.ignoreMatches || [];

--- a/src/index.js
+++ b/src/index.js
@@ -174,4 +174,14 @@ function depCheck(rootDir, options, cb) {
     .then(cb);
 }
 
+depCheck.detectors = {
+  importDeclaration: importDetector,
+  requireCallExpression: requireDetector,
+  gruntLoadTaskCallExpression: gruntLoadTaskDetector,
+};
+
+depCheck.parsers = {
+  default: defaultParser,
+};
+
 module.exports = depCheck;

--- a/test/cli.js
+++ b/test/cli.js
@@ -1,4 +1,4 @@
-/* global describe, it */
+/* global describe, it, before, after */
 
 import 'should';
 import fs from 'fs';
@@ -159,4 +159,31 @@ describe('depcheck command line', () => {
 
       exitCode.should.equal(-1);
     }));
+
+  describe('without specified directory', () => {
+    const expectedCwd = '/not/exist';
+    let originalCwd;
+
+    before(() => {
+      originalCwd = process.cwd;
+      process.cwd = () => expectedCwd;
+    });
+
+    it('should default to the current directory', () =>
+      new Promise(resolve => {
+        let error;
+
+        cli(
+          [],
+          data => data.should.fail(), // should not go into log output
+          data => error = data,
+          exitCode => resolve({ error, exitCode })
+        );
+      }).then(({ error, exitCode }) => {
+        error.should.containEql('not exist');
+        exitCode.should.equal(-1);
+      }));
+
+    after(() => process.cwd = originalCwd);
+  });
 });

--- a/test/fake_detectors/dependCallExpression.js
+++ b/test/fake_detectors/dependCallExpression.js
@@ -1,0 +1,7 @@
+export default node =>
+  node.type === 'CallExpression' &&
+  node.callee &&
+  node.callee.type === 'Identifier' &&
+  node.callee.name === 'depend'
+  ? node.arguments.map(arg => arg.value)
+  : [];

--- a/test/fake_detectors/exception.js
+++ b/test/fake_detectors/exception.js
@@ -1,0 +1,3 @@
+export default ast => {
+  throw ast; // throw anything it gets
+};

--- a/test/fake_modules/depend/index.js
+++ b/test/fake_modules/depend/index.js
@@ -1,0 +1,3 @@
+/* global depend */
+
+depend('depend-1', 'depend-2', 'depend-3');

--- a/test/fake_modules/depend/package.json
+++ b/test/fake_modules/depend/package.json
@@ -1,0 +1,7 @@
+{
+  "dependencies": {
+    "depend-1": "0.0.1",
+    "depend-2": "0.0.2",
+    "depend-3": "0.0.3"
+  }
+}

--- a/test/fake_modules/import_list/index.txt
+++ b/test/fake_modules/import_list/index.txt
@@ -1,0 +1,3 @@
+import-1
+import-2
+import-3

--- a/test/fake_modules/import_list/package.json
+++ b/test/fake_modules/import_list/package.json
@@ -1,0 +1,7 @@
+{
+  "dependencies": {
+    "import-1": "0.0.1",
+    "import-2": "0.0.2",
+    "import-3": "0.0.3"
+  }
+}

--- a/test/fake_modules/unreadable/package.json
+++ b/test/fake_modules/unreadable/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "unreadable": "0.0.1"
+  }
+}

--- a/test/fake_parsers/importList.js
+++ b/test/fake_parsers/importList.js
@@ -1,0 +1,10 @@
+export default content =>
+  content
+  .split('\n')
+  .filter(line => line)
+  .map(line => ({
+    type: 'ImportDeclaration',
+    source: {
+      value: line,
+    },
+  }));

--- a/test/index.js
+++ b/test/index.js
@@ -5,6 +5,8 @@ import depcheck from '../src/index';
 import fs from 'fs';
 import path from 'path';
 
+import exceptionDetector from './fake_detectors/exception';
+
 describe('depcheck', () => {
   const spec = fs.readFileSync(__dirname + '/spec.json', { encoding: 'utf8' });
   const testCases = JSON.parse(spec);
@@ -130,4 +132,23 @@ describe('depcheck', () => {
       'unreadable.js',
       ['unreadable'],
       []));
+
+  it('should work fine even a customer parser throws exceptions', done => {
+    const absolutePath = path.resolve('test/fake_modules/good');
+
+    depcheck(absolutePath, {
+      detectors: [
+        depcheck.detectors.requireCallExpression,
+        exceptionDetector,
+      ],
+    }, unused => {
+      unused.dependencies.should.deepEqual([]);
+      unused.devDependencies.should.deepEqual([]);
+
+      Object.keys(unused.invalidFiles).should.have.length(0);
+      Object.keys(unused.invalidDirs).should.have.length(0);
+
+      done();
+    });
+  });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -135,58 +135,38 @@ describe('depcheck', () => {
       ['unreadable'],
       []));
 
-  it('should work fine even a customer parser throws exceptions', done => {
-    const absolutePath = path.resolve('test/fake_modules/good');
+  function testCustomPluggableComponents(module, options) {
+    return depcheck(
+      path.resolve('test/fake_modules', module),
+      options,
+      unused => {
+        unused.dependencies.should.deepEqual([]);
+        unused.devDependencies.should.deepEqual([]);
 
-    depcheck(absolutePath, {
+        Object.keys(unused.invalidFiles).should.have.length(0);
+        Object.keys(unused.invalidDirs).should.have.length(0);
+      });
+  }
+
+  it('should work fine even a customer parser throws exceptions', () =>
+    testCustomPluggableComponents('good', {
       detectors: [
         depcheck.detectors.requireCallExpression,
         exceptionDetector,
       ],
-    }, unused => {
-      unused.dependencies.should.deepEqual([]);
-      unused.devDependencies.should.deepEqual([]);
+    }));
 
-      Object.keys(unused.invalidFiles).should.have.length(0);
-      Object.keys(unused.invalidDirs).should.have.length(0);
-
-      done();
-    });
-  });
-
-  it('should use custom parsers to generate AST', done => {
-    const absolutePath = path.resolve('test/fake_modules/import_list');
-
-    depcheck(absolutePath, {
+  it('should use custom parsers to generate AST', () =>
+    testCustomPluggableComponents('import_list', {
       parsers: {
         '.txt': importListParser,
       },
-    }, unused => {
-      unused.dependencies.should.deepEqual([]);
-      unused.devDependencies.should.deepEqual([]);
+    }));
 
-      Object.keys(unused.invalidFiles).should.have.length(0);
-      Object.keys(unused.invalidDirs).should.have.length(0);
-
-      done();
-    });
-  });
-
-  it('should use custom detector to find dependencies', done => {
-    const absolutePath = path.resolve('test/fake_modules/depend');
-
-    depcheck(absolutePath, {
+  it('should use custom detector to find dependencies', () =>
+    testCustomPluggableComponents('depend', {
       detectors: [
         dependDetector,
       ],
-    }, unused => {
-      unused.dependencies.should.deepEqual([]);
-      unused.devDependencies.should.deepEqual([]);
-
-      Object.keys(unused.invalidFiles).should.have.length(0);
-      Object.keys(unused.invalidDirs).should.have.length(0);
-
-      done();
-    });
-  });
+    }));
 });

--- a/test/index.js
+++ b/test/index.js
@@ -85,9 +85,9 @@ describe('depcheck', () => {
 
   describe('access unreadable directory', () => {
     testAccessUnreadableDirectory(
-      'bad',
       'unreadable',
-      ['optimist'],
+      'unreadable',
+      ['unreadable'],
       []);
   });
 

--- a/test/index.js
+++ b/test/index.js
@@ -7,6 +7,7 @@ import path from 'path';
 
 import importListParser from './fake_parsers/importList';
 import exceptionDetector from './fake_detectors/exception';
+import dependDetector from './fake_detectors/dependCallExpression';
 
 describe('depcheck', () => {
   const spec = fs.readFileSync(__dirname + '/spec.json', { encoding: 'utf8' });
@@ -160,6 +161,24 @@ describe('depcheck', () => {
       parsers: {
         '.txt': importListParser,
       },
+    }, unused => {
+      unused.dependencies.should.deepEqual([]);
+      unused.devDependencies.should.deepEqual([]);
+
+      Object.keys(unused.invalidFiles).should.have.length(0);
+      Object.keys(unused.invalidDirs).should.have.length(0);
+
+      done();
+    });
+  });
+
+  it('should use custom detector to find dependencies', done => {
+    const absolutePath = path.resolve('test/fake_modules/depend');
+
+    depcheck(absolutePath, {
+      detectors: [
+        dependDetector,
+      ],
     }, unused => {
       unused.dependencies.should.deepEqual([]);
       unused.devDependencies.should.deepEqual([]);

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,6 @@
 /* global describe, it, before, after */
 
-import assert from 'should';
+import 'should';
 import depcheck from '../src/index';
 import fs from 'fs';
 import path from 'path';
@@ -23,11 +23,11 @@ describe('depcheck', () => {
     });
   });
 
-  it('should ignore bad javascript', function testBadJS(done) {
+  it('should ignore bad javascript', done => {
     const absolutePath = path.resolve('test/fake_modules/bad_js');
 
-    depcheck(absolutePath, {  }, function checked(unused) {
-      unused.dependencies.should.have.length(1);
+    depcheck(absolutePath, {}, unused => {
+      unused.dependencies.should.deepEqual(['optimist']);
 
       const invalidFiles = Object.keys(unused.invalidFiles);
       invalidFiles.should.have.length(1);
@@ -40,7 +40,7 @@ describe('depcheck', () => {
     });
   });
 
-  it('should allow dynamic package metadata', function testDynamic(done) {
+  it('should allow dynamic package metadata', done => {
     const absolutePath = path.resolve('test/fake_modules/bad');
 
     depcheck(absolutePath, {
@@ -50,8 +50,8 @@ describe('depcheck', () => {
           'express': '^4.0.0',
         },
       },
-    }, function checked(unused) {
-      assert.equal(unused.dependencies.length, 2);
+    }, unused => {
+      unused.dependencies.should.deepEqual(['optimist', 'express']);
       done();
     });
   });

--- a/test/index.js
+++ b/test/index.js
@@ -5,6 +5,7 @@ import depcheck from '../src/index';
 import fs from 'fs';
 import path from 'path';
 
+import importListParser from './fake_parsers/importList';
 import exceptionDetector from './fake_detectors/exception';
 
 describe('depcheck', () => {
@@ -141,6 +142,24 @@ describe('depcheck', () => {
         depcheck.detectors.requireCallExpression,
         exceptionDetector,
       ],
+    }, unused => {
+      unused.dependencies.should.deepEqual([]);
+      unused.devDependencies.should.deepEqual([]);
+
+      Object.keys(unused.invalidFiles).should.have.length(0);
+      Object.keys(unused.invalidDirs).should.have.length(0);
+
+      done();
+    });
+  });
+
+  it('should use custom parsers to generate AST', done => {
+    const absolutePath = path.resolve('test/fake_modules/import_list');
+
+    depcheck(absolutePath, {
+      parsers: {
+        '.txt': importListParser,
+      },
     }, unused => {
       unused.dependencies.should.deepEqual([]);
       unused.devDependencies.should.deepEqual([]);


### PR DESCRIPTION
- Pass custom parser (reference #27)
- Pass custom detector (reference #27)
- Throw exception from detector could be handled (reference #27)
- Access unreadable file
- Not specify directory to depCheck CLI
- Refine test case codes

Fix bugs:
- Expose out-of-box parsers and detectors to `depCheck` object.
