### PR TITLE
Convert all test cases to promise-async mode.

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -9,28 +9,30 @@ import importListParser from './fake_parsers/importList';
 import exceptionDetector from './fake_detectors/exception';
 import dependDetector from './fake_detectors/dependCallExpression';
 
+function check(module, options) {
+  return new Promise(resolve =>
+    depcheck(
+      path.resolve(__dirname, 'fake_modules', module),
+      options,
+      resolve));
+}
+
 describe('depcheck', () => {
-  const spec = fs.readFileSync(__dirname + '/spec.json', { encoding: 'utf8' });
+  const specPath = path.resolve(__dirname, 'spec.json');
+  const spec = fs.readFileSync(specPath, { encoding: 'utf8' });
   const testCases = JSON.parse(spec);
 
   testCases.forEach(testCase => {
-    it('should ' + testCase.name, done => {
-      const testPath = path.resolve(__dirname, 'fake_modules', testCase.module);
-      const options = testCase.options;
-      const expected = testCase.expected;
-
-      depcheck(testPath, options, result => {
+    it('should ' + testCase.name, () =>
+      check(testCase.module, testCase.options).then(result => {
+        const expected = testCase.expected;
         result.dependencies.should.eql(expected.dependencies);
         result.devDependencies.should.eql(expected.devDependencies);
-        done();
-      });
-    });
+      }));
   });
 
-  it('should ignore bad javascript', done => {
-    const absolutePath = path.resolve(__dirname, 'fake_modules/bad_js');
-
-    depcheck(absolutePath, {}, unused => {
+  it('should ignore bad javascript', () =>
+    check('bad_js', {}).then(unused => {
       unused.dependencies.should.deepEqual(['optimist']);
 
       const invalidFiles = Object.keys(unused.invalidFiles);
@@ -39,36 +41,29 @@ describe('depcheck', () => {
 
       const error = unused.invalidFiles[invalidFiles[0]];
       error.should.be.instanceof(SyntaxError);
+    }));
 
-      done();
-    });
-  });
-
-  it('should allow dynamic package metadata', done => {
-    const absolutePath = path.resolve(__dirname, 'fake_modules/bad');
-
-    depcheck(absolutePath, {
+  it('should allow dynamic package metadata', () =>
+    check('bad', {
       'package': {
         'dependencies': {
           'optimist': '~0.6.0',
           'express': '^4.0.0',
         },
       },
-    }, unused => {
+    }).then(unused => {
       unused.dependencies.should.deepEqual(['optimist', 'express']);
-      done();
-    });
-  });
+    }));
 
   function testAccessUnreadableDirectory(
     module, unreadable, unusedDeps, unusedDevDeps) {
-    const modulePath = path.resolve(__dirname, 'fake_modules', module);
-    const unreadablePath = path.resolve(modulePath, unreadable);
+    const unreadablePath =
+      path.resolve(__dirname, 'fake_modules', module, unreadable);
 
     before(done => fs.mkdir(unreadablePath, '0000', done));
 
-    it('should capture error', done =>
-      depcheck(modulePath, {}, unused => {
+    it('should capture error', () =>
+      check(module, {}).then(unused => {
         unused.dependencies.should.deepEqual(unusedDeps);
         unused.devDependencies.should.deepEqual(unusedDevDeps);
 
@@ -78,8 +73,6 @@ describe('depcheck', () => {
         const error = unused.invalidDirs[invalidDirs[0]];
         error.should.be.instanceof(Error);
         error.toString().should.containEql('EACCES');
-
-        done();
       }));
 
     after(done =>
@@ -103,13 +96,13 @@ describe('depcheck', () => {
 
   function testAccessUnreadableFile(
     module, unreadable, unusedDeps, unusedDevDeps) {
-    const modulePath = path.resolve(__dirname, 'fake_modules', module);
-    const unreadablePath = path.resolve(modulePath, unreadable);
+    const unreadablePath =
+      path.resolve(__dirname, 'fake_modules', module, unreadable);
 
     before(done => fs.writeFile(unreadablePath, '', { mode: 0 }, done));
 
-    it('should capture error', done =>
-      depcheck(modulePath, {}, unused => {
+    it('should capture error', () =>
+      check(module, {}).then(unused => {
         unused.dependencies.should.deepEqual(unusedDeps);
         unused.devDependencies.should.deepEqual(unusedDevDeps);
 
@@ -119,8 +112,6 @@ describe('depcheck', () => {
         const error = unused.invalidFiles[invalidFiles[0]];
         error.should.be.instanceof(Error);
         error.toString().should.containEql('EACCES');
-
-        done();
       }));
 
     after(done =>
@@ -136,16 +127,13 @@ describe('depcheck', () => {
       []));
 
   function testCustomPluggableComponents(module, options) {
-    return depcheck(
-      path.resolve(__dirname, 'fake_modules', module),
-      options,
-      unused => {
-        unused.dependencies.should.deepEqual([]);
-        unused.devDependencies.should.deepEqual([]);
+    return check(module, options).then(unused => {
+      unused.dependencies.should.deepEqual([]);
+      unused.devDependencies.should.deepEqual([]);
 
-        Object.keys(unused.invalidFiles).should.have.length(0);
-        Object.keys(unused.invalidDirs).should.have.length(0);
-      });
+      Object.keys(unused.invalidFiles).should.have.length(0);
+      Object.keys(unused.invalidDirs).should.have.length(0);
+    });
   }
 
   it('should work fine even a customer parser throws exceptions', () =>

--- a/test/index.js
+++ b/test/index.js
@@ -15,7 +15,7 @@ describe('depcheck', () => {
 
   testCases.forEach(testCase => {
     it('should ' + testCase.name, done => {
-      const testPath = path.resolve('test/fake_modules/' + testCase.module);
+      const testPath = path.resolve(__dirname, 'fake_modules', testCase.module);
       const options = testCase.options;
       const expected = testCase.expected;
 
@@ -28,7 +28,7 @@ describe('depcheck', () => {
   });
 
   it('should ignore bad javascript', done => {
-    const absolutePath = path.resolve('test/fake_modules/bad_js');
+    const absolutePath = path.resolve(__dirname, 'fake_modules/bad_js');
 
     depcheck(absolutePath, {}, unused => {
       unused.dependencies.should.deepEqual(['optimist']);
@@ -45,7 +45,7 @@ describe('depcheck', () => {
   });
 
   it('should allow dynamic package metadata', done => {
-    const absolutePath = path.resolve('test/fake_modules/bad');
+    const absolutePath = path.resolve(__dirname, 'fake_modules/bad');
 
     depcheck(absolutePath, {
       'package': {
@@ -137,7 +137,7 @@ describe('depcheck', () => {
 
   function testCustomPluggableComponents(module, options) {
     return depcheck(
-      path.resolve('test/fake_modules', module),
+      path.resolve(__dirname, 'fake_modules', module),
       options,
       unused => {
         unused.dependencies.should.deepEqual([]);


### PR DESCRIPTION
- When using mocha `done` callback, it will go into done-async mode. When fail in done-async mode, the test case hangs and shows _timeout_ finally. The actual failure information is lost. :disappointed: 
- When the test case returns a promise, it will go into promise-async mode. In such mode, when a test case fails, the test case fail **immediately** and shows the actual failure information. :smiley: 
- Convert all test cases to promise-async mode.
