### PR TITLE
Fix a bug about require dynamic expression 

### DIFF
--- a/src/detectors/requireCallExpression.js
+++ b/src/detectors/requireCallExpression.js
@@ -3,6 +3,7 @@ export default node =>
   node.callee &&
   node.callee.type === 'Identifier' &&
   node.callee.name === 'require' &&
-  node.arguments[0]
+  node.arguments[0] &&
+  typeof node.arguments[0].value === 'string'
   ? [node.arguments[0].value]
   : [];

--- a/src/index.js
+++ b/src/index.js
@@ -115,7 +115,9 @@ function checkDirectory(dir, ignoreDirs, deps, devDeps, parsers, detectors) {
       promises.push(getDependencies(parsers, detectors, filename)
         .then(dependencies =>
           dependencies.map(dependency =>
-            dependency.replace ? dependency.replace(/\/.*$/, '') : dependency))
+            dependency && dependency.replace
+            ? dependency.replace(/\/.*$/, '')
+            : dependency))
         .then(used => ({
           dependencies: minus(deps, used),
           devDependencies: minus(devDeps, used),

--- a/test/fake_modules/require_dynamic/index.js
+++ b/test/fake_modules/require_dynamic/index.js
@@ -1,0 +1,4 @@
+/* global a */
+
+require('dynamic');
+require(a.dynamic.call());

--- a/test/fake_modules/require_dynamic/package.json
+++ b/test/fake_modules/require_dynamic/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "dynamic": "0.0.1"
+  }
+}

--- a/test/spec.json
+++ b/test/spec.json
@@ -138,6 +138,16 @@
     }
   },
   {
+    "name": "handle require call with dynamic expression",
+    "module": "require_dynamic",
+    "options": {
+    },
+    "expected": {
+      "dependencies": [],
+      "devDependencies": []
+    }
+  },
+  {
     "name": "ignore ignoreDirs",
     "module": "bad_deep",
     "options": {


### PR DESCRIPTION
Bug:
- When a file require a dynamic expression, the `requireCallExpression` detector return `undefined`
- In detection result process, the `dependency.replace` throws exception when encounter `undefined`
- Fix the bug in both places, add covering test case.
