### PR TITLE
Add ignore-bin-package switch to options.

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -33,7 +33,7 @@ export default function cli(args, log, error, exit) {
     .describe('ignore-bin-package', 'Ignore package with bin entry')
     .describe('json', 'Output results to JSON')
     .describe('ignores', 'Comma separated package list to ignore')
-    .describe('ignoreDirs', 'Comma separated folder names to ignore')
+    .describe('ignore-dirs', 'Comma separated folder names to ignore')
     .describe('help', 'Show this help message');
 
   if (opt.argv.help) {

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,5 +1,5 @@
 import yargs from 'yargs';
-import checkDirectory from './index';
+import depcheck from './index';
 import fs from 'fs';
 import path from 'path';
 
@@ -21,9 +21,16 @@ function prettify(caption, deps) {
 export default function cli(args, log, error, exit) {
   const opt = yargs(args)
     .usage('Usage: $0 [DIRECTORY]')
-    .boolean('dev')
-    .default('dev', true)
+    .boolean([
+      'dev',
+      'ignore-bin-package',
+    ])
+    .default({
+      'dev': true,
+      'ignore-bin-package': true,
+    })
     .describe('dev', 'Check on devDependecies')
+    .describe('ignore-bin-package', 'Ignore package with bin entry')
     .describe('json', 'Output results to JSON')
     .describe('ignores', 'Comma separated package list to ignore')
     .describe('ignoreDirs', 'Comma separated folder names to ignore')
@@ -47,8 +54,9 @@ export default function cli(args, log, error, exit) {
       log(opt.help());
       exit(-1);
     })
-    .then(() => checkDirectory(rootDir, {
+    .then(() => depcheck(rootDir, {
       withoutDev: !opt.argv.dev,
+      ignoreBinPackage: opt.argv.ignoreBinPackage,
       ignoreMatches: (opt.argv.ignores || '').split(','),
       ignoreDirs: (opt.argv.ignoreDirs || '').split(','),
     }, unused => {

--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,9 @@ const availableParsers = constructComponent(component, 'parser');
 const availableDetectors = constructComponent(component, 'detector');
 
 const defaultOptions = {
+  withoutDev: false,
+  ignoreMatches: [
+  ],
   ignoreDirs: [
     '.git',
     '.svn',
@@ -35,6 +38,10 @@ const defaultOptions = {
     availableDetectors.gruntLoadTaskCallExpression,
   ],
 };
+
+function getOrDefault(opt, key) {
+  return typeof opt[key] !== 'undefined' ? opt[key] : defaultOptions[key];
+}
 
 function unifyParser(parsers) {
   return Object.assign({}, ...Object.keys(parsers).map(key => ({
@@ -168,16 +175,17 @@ function filterDependencies(rootDir, ignoreMatches, dependencies) {
 }
 
 export default function depcheck(rootDir, options, cb) {
-  const parsers = unifyParser(options.parsers || defaultOptions.parsers);
-  const detectors = options.detectors || defaultOptions.detectors;
-  const ignoreMatches = options.ignoreMatches || [];
+  const withoutDev = getOrDefault(options, 'withoutDev');
+  const parsers = unifyParser(getOrDefault(options, 'parsers'));
+  const detectors = getOrDefault(options, 'detectors');
+  const ignoreMatches = getOrDefault(options, 'ignoreMatches');
   const ignoreDirs = unique(defaultOptions.ignoreDirs.concat(options.ignoreDirs));
 
   const metadata = options.package || require(path.join(rootDir, 'package.json'));
   const dependencies = metadata.dependencies || {};
   const devDependencies = metadata.devDependencies || {};
   const deps = filterDependencies(rootDir, ignoreMatches, dependencies);
-  const devDeps = filterDependencies(rootDir, ignoreMatches, options.withoutDev ? [] : devDependencies);
+  const devDeps = filterDependencies(rootDir, ignoreMatches, withoutDev ? [] : devDependencies);
 
   return checkDirectory(rootDir, ignoreDirs, deps, devDeps, parsers, detectors)
     .then(cb);

--- a/test/cli.js
+++ b/test/cli.js
@@ -23,7 +23,7 @@ function makeArgv(testCase) {
   }
 
   if (options.ignoreDirs) {
-    argv.push('--ignoreDirs=' + options.ignoreDirs.join(','));
+    argv.push('--ignore-dirs=' + options.ignoreDirs.join(','));
   }
 
   return argv;

--- a/test/cli.js
+++ b/test/cli.js
@@ -14,6 +14,10 @@ function makeArgv(testCase) {
     argv.push('--dev=false');
   }
 
+  if (typeof options.ignoreBinPackage !== 'undefined') {
+    argv.push('--ignore-bin-package=' + options.ignoreBinPackage);
+  }
+
   if (options.ignoreMatches) {
     argv.push('--ignores=' + options.ignoreMatches.join(','));
   }

--- a/test/spec.json
+++ b/test/spec.json
@@ -118,6 +118,17 @@
     }
   },
   {
+    "name": "not ignore bin dependencies when ignoreBinPackage is false",
+    "module": "bin_js",
+    "options": {
+      "ignoreBinPackage": false
+    },
+    "expected": {
+      "dependencies": ["anybin"],
+      "devDependencies": []
+    }
+  },
+  {
     "name": "handle require call without parameters",
     "module": "require_nothing",
     "options": {


### PR DESCRIPTION
- Set the option default value to `true` for backward compatible
- Use can turn off ignore by API and CLI.
- When the _special_ parser from [pluggable design](https://github.com/lijunle/depcheck-es6/issues/27) is powerful enough, it will recommend to turn off the switch.
