### PR TITLE
Accept parser and detector from CLI options.

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -18,6 +18,21 @@ function prettify(caption, deps) {
   return list.length ? [caption].concat(list) : [];
 }
 
+function getParsers(parsers) {
+  return typeof parsers === 'undefined'
+    ? undefined
+    : Object.assign({}, ...parsers.split(',').map(keyValuePair => {
+      const [glob, value] = keyValuePair.split(':');
+      return { [glob]: value.split('&').map(name => depcheck.parser[name]) };
+    }));
+}
+
+function getDetectors(detectors) {
+  return typeof detectors === 'undefined'
+    ? undefined
+    : detectors.split(',').map(name => depcheck.detector[name]);
+}
+
 export default function cli(args, log, error, exit) {
   const opt = yargs(args)
     .usage('Usage: $0 [DIRECTORY]')
@@ -34,6 +49,8 @@ export default function cli(args, log, error, exit) {
     .describe('json', 'Output results to JSON')
     .describe('ignores', 'Comma separated package list to ignore')
     .describe('ignore-dirs', 'Comma separated folder names to ignore')
+    .describe('parsers', 'Comma separated glob:pasers pair list')
+    .describe('detectors', 'Comma separated detector list')
     .describe('help', 'Show this help message');
 
   if (opt.argv.help) {
@@ -59,6 +76,8 @@ export default function cli(args, log, error, exit) {
       ignoreBinPackage: opt.argv.ignoreBinPackage,
       ignoreMatches: (opt.argv.ignores || '').split(','),
       ignoreDirs: (opt.argv.ignoreDirs || '').split(','),
+      parsers: getParsers(opt.argv.parsers),
+      detectors: getDetectors(opt.argv.detectors),
     }, unused => {
       if (opt.argv.json) {
         log(JSON.stringify(unused));

--- a/test/cli.js
+++ b/test/cli.js
@@ -169,6 +169,69 @@ describe('depcheck command line', () => {
       exitCode.should.equal(-1);
     }));
 
+  it('should recognize JSX file even only pass jsx parser and require detector', () =>
+    new Promise(resolve => {
+      let log = '';
+
+      cli(
+        [path.resolve(__dirname, 'fake_modules/jsx'), '--parsers="*.jsx:jsx"', '--dectors=requireCallExpression'],
+        data => log = data,
+        data => data.should.fail(), // should not go into error output
+        exitCode => resolve({
+          logs: log.split('\n'),
+          exitCode,
+        })
+      );
+    }).then(({ logs, exitCode }) => {
+      logs.should.have.length(2);
+      logs[0].should.equal('Unused Dependencies');
+      logs[1].should.containEql('react');
+
+      exitCode.should.equal(-1);
+    }));
+
+  it('should not recognize JSX file when not pass jsx parser', () =>
+    new Promise(resolve => {
+      let log = '';
+
+      cli(
+        [path.resolve(__dirname, 'fake_modules/jsx'), '--parsers="*.jsx:es6"'],
+        data => log = data,
+        data => data.should.fail(), // should not go into error output
+        exitCode => resolve({
+          logs: log.split('\n'),
+          exitCode,
+        })
+      );
+    }).then(({ logs, exitCode }) => {
+      logs.should.have.length(2);
+      logs[0].should.equal('Unused Dependencies');
+      logs[1].should.containEql('react');
+
+      exitCode.should.equal(-1);
+    }));
+
+  it('should not recognize JSX file when not enable require detector', () =>
+    new Promise(resolve => {
+      let log = '';
+
+      cli(
+        [path.resolve(__dirname, 'fake_modules/jsx'), '--detectors=importDeclaration'],
+        data => log = data,
+        data => data.should.fail(), // should not go into error output
+        exitCode => resolve({
+          logs: log.split('\n'),
+          exitCode,
+        })
+      );
+    }).then(({ logs, exitCode }) => {
+      logs.should.have.length(2);
+      logs[0].should.equal('Unused Dependencies');
+      logs[1].should.containEql('react');
+
+      exitCode.should.equal(-1);
+    }));
+
   describe('without specified directory', () => {
     const expectedCwd = '/not/exist';
     let originalCwd;


### PR DESCRIPTION
- CLI options are plain string, so only out-of-box parsers and detectors
  can be accessed.
- Detectors CLI option looks like:
  
  ```
  --detectors=requireCallExression,importDeclaration
  ```
- Parsers CLI option look like (`"` is critical to avoid cmd escape):
  
  ```
  --parsers="*.js:es6,*.jsx:jsx,*.csv:csv1&csv2"
  ```
