### PR TITLE
Add the first special parser - bin.

### DIFF
--- a/build/component.js
+++ b/build/component.js
@@ -18,10 +18,13 @@ function getList(name) {
 Promise.all([
   getList('parser'),
   getList('detector'),
+  getList('special'),
 ]).then(([
   parser,
   detector,
+  special,
 ]) => console.log(JSON.stringify({
   parser,
   detector,
+  special,
 }, null, 2)));

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "component": "babel-node ./build/component.js > ./dist/component.json",
     "compile": "babel --optional runtime src/ -d dist/",
-    "depcheck": "./bin/depcheck --ignore-bin-package=false --specials=bin --ignores=babel-eslint,coveralls,eslint-config-airbnb,mocha-lcov-reporter",
+    "depcheck": "./bin/depcheck --ignore-bin-package=false --specials=bin --ignores=babel-eslint,eslint-config-airbnb,mocha-lcov-reporter",
     "prepublish": "npm run compile && npm run component",
     "lint": "./node_modules/.bin/eslint ./src ./test",
     "test": "mocha --compilers js:babel/register ./test",
@@ -30,6 +30,7 @@
     "acorn": "^2.4.0",
     "acorn-jsx": "^2.0.0",
     "babel-runtime": "^5.8.25",
+    "js-yaml": "^3.4.2",
     "minimatch": "^2.0.1",
     "node-source-walk": "^2.0.0",
     "walkdir": "0.0.10",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "component": "babel-node ./build/component.js > ./dist/component.json",
     "compile": "babel --optional runtime src/ -d dist/",
-    "depcheck": "./bin/depcheck --ignore-bin-package=false --ignores=babel,babel-eslint,coveralls,eslint,eslint-config-airbnb,isparta,mocha,mocha-lcov-reporter",
+    "depcheck": "./bin/depcheck --ignore-bin-package=false --specials=bin --ignores=babel-eslint,coveralls,eslint-config-airbnb,mocha-lcov-reporter",
     "prepublish": "npm run compile && npm run component",
     "lint": "./node_modules/.bin/eslint ./src ./test",
     "test": "mocha --compilers js:babel/register ./test",

--- a/src/cli.js
+++ b/src/cli.js
@@ -33,6 +33,12 @@ function getDetectors(detectors) {
     : detectors.split(',').map(name => depcheck.detector[name]);
 }
 
+function getSpecials(specials) {
+  return typeof specials === 'undefined'
+    ? undefined
+    : specials.split(',').map(name => depcheck.special[name]);
+}
+
 export default function cli(args, log, error, exit) {
   const opt = yargs(args)
     .usage('Usage: $0 [DIRECTORY]')
@@ -51,6 +57,7 @@ export default function cli(args, log, error, exit) {
     .describe('ignore-dirs', 'Comma separated folder names to ignore')
     .describe('parsers', 'Comma separated glob:pasers pair list')
     .describe('detectors', 'Comma separated detector list')
+    .describe('specials', 'Comma separated special parser list')
     .describe('help', 'Show this help message');
 
   if (opt.argv.help) {
@@ -78,6 +85,7 @@ export default function cli(args, log, error, exit) {
       ignoreDirs: (opt.argv.ignoreDirs || '').split(','),
       parsers: getParsers(opt.argv.parsers),
       detectors: getDetectors(opt.argv.detectors),
+      specials: getSpecials(opt.argv.specials),
     }, unused => {
       if (opt.argv.json) {
         log(JSON.stringify(unused));

--- a/src/component.json
+++ b/src/component.json
@@ -7,5 +7,7 @@
     "gruntLoadTaskCallExpression",
     "importDeclaration",
     "requireCallExpression"
+  ],
+  "special": [
   ]
 }

--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,8 @@ const availableParsers = constructComponent(component, 'parser');
 
 const availableDetectors = constructComponent(component, 'detector');
 
+const availableSpecials = constructComponent(component, 'special');
+
 const defaultOptions = {
   withoutDev: false,
   ignoreBinPackage: true,
@@ -37,6 +39,8 @@ const defaultOptions = {
     availableDetectors.importDeclaration,
     availableDetectors.requireCallExpression,
     availableDetectors.gruntLoadTaskCallExpression,
+  ],
+  specials: [
   ],
 };
 
@@ -180,10 +184,13 @@ function filterDependencies(rootDir, ignoreBinPackage, ignoreMatches, dependenci
 export default function depcheck(rootDir, options, cb) {
   const withoutDev = getOrDefault(options, 'withoutDev');
   const ignoreBinPackage = getOrDefault(options, 'ignoreBinPackage');
-  const parsers = unifyParser(getOrDefault(options, 'parsers'));
-  const detectors = getOrDefault(options, 'detectors');
   const ignoreMatches = getOrDefault(options, 'ignoreMatches');
   const ignoreDirs = unique(defaultOptions.ignoreDirs.concat(options.ignoreDirs));
+
+  const detectors = getOrDefault(options, 'detectors');
+  const parsers = Object.assign(
+    { '*': getOrDefault(options, 'specials') },
+    unifyParser(getOrDefault(options, 'parsers')));
 
   const metadata = options.package || require(path.join(rootDir, 'package.json'));
   const dependencies = metadata.dependencies || {};
@@ -197,3 +204,4 @@ export default function depcheck(rootDir, options, cb) {
 
 depcheck.parser = availableParsers;
 depcheck.detector = availableDetectors;
+depcheck.special = availableSpecials;

--- a/src/index.js
+++ b/src/index.js
@@ -104,7 +104,7 @@ function getDependencies(dir, filename, deps, parser, detectors) {
 function checkFile(dir, filename, deps, devDeps, parsers, detectors) {
   const basename = path.basename(filename);
   const targets = [].concat(...Object.keys(parsers)
-    .filter(glob => minimatch(basename, glob))
+    .filter(glob => minimatch(basename, glob, { dot: true }))
     .map(key => parsers[key]));
 
   return targets.map(parser =>

--- a/src/special/bin.js
+++ b/src/special/bin.js
@@ -1,0 +1,15 @@
+function makeRequireNode(dependency) {
+  return {
+    type: 'CallExpression',
+    callee: {
+      type: 'Identifier',
+      name: 'require',
+    },
+    arguments: [
+      { value: dependency },
+    ],
+  };
+}
+
+export default (content, filename, deps, dir) =>
+  makeRequireNode('bin');

--- a/src/special/bin.js
+++ b/src/special/bin.js
@@ -1,3 +1,22 @@
+import path from 'path';
+
+function getObjectValues(obj) {
+  return Object.keys(obj).map(key => obj[key]);
+}
+
+function getBin(dir, dependency) {
+  const packagePath = path.resolve(dir, 'node_modules', dependency, 'package.json');
+  const metadata = require(packagePath);
+  return metadata.bin || {};
+}
+
+function isUsing(dep, bin, value, scripts) {
+  return scripts.some(script =>
+    script.indexOf(bin) === 0 ||
+    script.indexOf(`./node_modules/.bin/${bin}`) !== -1 ||
+    script.indexOf(path.join('node_modules', dep, value) !== -1));
+}
+
 function makeRequireNode(dependency) {
   return {
     type: 'CallExpression',
@@ -11,5 +30,18 @@ function makeRequireNode(dependency) {
   };
 }
 
-export default (content, filename, deps, dir) =>
-  makeRequireNode('bin');
+export default (content, filename, deps, dir) => {
+  const basename = path.basename(filename);
+  if (basename === 'package.json') {
+    const scripts = getObjectValues(JSON.parse(content).scripts || {});
+    return deps
+      .filter(dep => {
+        const bin = getBin(dir, dep);
+        return Object.keys(bin).some(key =>
+          isUsing(dep, key, bin[key], scripts));
+      })
+      .map(makeRequireNode);
+  }
+
+  return {};
+};


### PR DESCRIPTION
- Implement the special parser infrastructure. Reference #27 
- The `bin` special parser check on `package.json` and `.travis.yml` file to detect which binaries are **really** in use.
- Combine the `bin` special parser with `--ignore-bin-package=false` option to do smarter check.
- For self check, many packages not need to explicitly ignore with `bin` special parser.
