### PR TITLE
Finally find that, mocha-lcov-reporter is useless.

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "component": "babel-node ./build/component.js > ./dist/component.json",
     "compile": "babel --optional runtime src/ -d dist/",
-    "depcheck": "./bin/depcheck --ignore-bin-package=false --specials=bin,eslint --ignores=mocha-lcov-reporter",
+    "depcheck": "./bin/depcheck --ignore-bin-package=false --specials=bin,eslint",
     "prepublish": "npm run compile && npm run component",
     "lint": "./node_modules/.bin/eslint ./src ./test",
     "test": "mocha --compilers js:babel/register ./test",
@@ -44,7 +44,6 @@
     "eslint-config-airbnb": "0.1.0",
     "isparta": "^3.0.4",
     "mocha": "^2.1.0",
-    "mocha-lcov-reporter": "1.0.0",
     "should": "^7.1.0"
   }
 }


### PR DESCRIPTION
- The `lcovonly` reporter is provided by Istanbul
- Istanbul has not install `mocha-lcov-reporter` too. [Reference](https://github.com/gotwarlost/istanbul/blob/c87ada03cb485e4f9110224899b68d8dc27e4bf3/package.json#L76).
