### PR TITLE
Revert CLI output to old format.

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -14,7 +14,7 @@ function noUnused(unused) {
 }
 
 function prettify(caption, deps) {
-  const list = deps.map(dep => `- ${dep}`);
+  const list = deps.map(dep => `* ${dep}`);
   return list.length ? [caption].concat(list) : [];
 }
 
@@ -95,7 +95,7 @@ export default function cli(args, log, error, exit) {
         exit(0);
       } else {
         log(prettify('Unused Dependencies', unused.dependencies)
-          .concat(prettify('Unused devDependencies', unused.devDependencies))
+          .concat(prettify('\nUnused devDependencies', unused.devDependencies))
           .join('\n'));
         exit(-1);
       }

--- a/test/cli.js
+++ b/test/cli.js
@@ -49,8 +49,8 @@ function testCli(argv) {
         log,
         error,
         exitCode,
-        logs: log.split('\n'),
-        errors: error.split('\n'),
+        logs: log.split('\n').filter(line => line),
+        errors: error.split('\n').filter(line => line),
       })));
 }
 

--- a/test/e2e.js
+++ b/test/e2e.js
@@ -25,5 +25,5 @@ describe('depcheck end-to-end', () => {
     testE2E('good', ['No unused dependencies']));
 
   it('should find unused dependencies', () =>
-    testE2E('bad', ['Unused Dependencies', '- optimist']));
+    testE2E('bad', ['Unused Dependencies', '* optimist']));
 });


### PR DESCRIPTION
- It is same with old depcheck output format now.
- Update test code.
