### PR TITLE
Add Windows Build Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,19 @@
 # depcheck-es6
 
-[![build status](https://secure.travis-ci.org/lijunle/depcheck-es6.svg?branch=master)](http://travis-ci.org/lijunle/depcheck-es6)
-[![Coverage Status](https://coveralls.io/repos/lijunle/depcheck-es6/badge.svg?branch=master&service=github)](https://coveralls.io/github/lijunle/depcheck-es6?branch=master)
-[![Dependency Status](https://david-dm.org/lijunle/depcheck-es6.svg)](https://david-dm.org/lijunle/depcheck-es6)
-[![devDependency Status](https://david-dm.org/lijunle/depcheck-es6/dev-status.svg)](https://david-dm.org/lijunle/depcheck-es6#info=devDependencies)
-
 *Note*: This project is forked from rumpl's [depcheck](https://github.com/rumpl/depcheck), while extended to support **ES6**, **JSX** and more features. This fork is fully backward compatible with depcheck.
 
 Keeping track of your dependencies is not an easy task, especially if you have a big project. Are you sure you are using all of the dependencies you define in your `package.json` file? One way to find out is to look at all your files and check which modules you are using, but that's too time consuming. Or maybe you can do a `grep` on all the files of your project, and then some `grep -v` to remove the junk. But that's a hassle too.
 
 And that is why `depcheck` exists - it's a nifty little tool that looks at your project files and scans your code in order to find any unused dependencies.
+
+## Build Status
+
+[![build status](https://secure.travis-ci.org/lijunle/depcheck-es6.svg?branch=master)](http://travis-ci.org/lijunle/depcheck-es6)
+[![Build status](https://ci.appveyor.com/api/projects/status/w774aev2mj0s2hlf/branch/master?svg=true)](https://ci.appveyor.com/project/lijunle/depcheck-es6/branch/master)
+[![Coverage Status](https://coveralls.io/repos/lijunle/depcheck-es6/badge.svg?branch=master&service=github)](https://coveralls.io/github/lijunle/depcheck-es6?branch=master)
+
+[![Dependency Status](https://david-dm.org/lijunle/depcheck-es6.svg)](https://david-dm.org/lijunle/depcheck-es6)
+[![devDependency Status](https://david-dm.org/lijunle/depcheck-es6/dev-status.svg)](https://david-dm.org/lijunle/depcheck-es6#info=devDependencies)
 
 ## Installation
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,9 @@ environment:
   - nodejs_version: '3'
   - nodejs_version: '4'
 
+cache:
+  - node_modules -> package.json
+
 install:
   - ps: Install-Product node $env:nodejs_version
   - npm install

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,19 @@
+environment:
+  matrix:
+  - nodejs_version: '0.10'
+  - nodejs_version: '0.12'
+  - nodejs_version: '3'
+  - nodejs_version: '4'
+
+install:
+  - ps: Install-Product node $env:nodejs_version
+  - npm install
+
+test_script:
+  - node --version
+  - npm --version
+  - npm run depcheck
+  - npm run lint
+  - npm test
+
+build: off

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "component": "babel-node ./build/component.js > ./dist/component.json",
     "compile": "babel --optional runtime src/ -d dist/",
-    "depcheck": "./bin/depcheck --ignore-bin-package=false --specials=bin,eslint",
+    "depcheck": "node ./bin/depcheck --ignore-bin-package=false --specials=bin,eslint",
     "prepublish": "npm run compile && npm run component",
     "lint": "./node_modules/.bin/eslint ./src ./test",
     "test": "mocha --compilers js:babel/register ./test ./test/special",

--- a/src/special/bin.js
+++ b/src/special/bin.js
@@ -5,6 +5,10 @@ function getObjectValues(obj) {
   return Object.keys(obj).map(key => obj[key]);
 }
 
+function join(...args) {
+  return path.join(...args).replace(/\\/g, '/');
+}
+
 function getBin(dir, dependency) {
   const packagePath = path.resolve(dir, 'node_modules', dependency, 'package.json');
   const metadata = require(packagePath);
@@ -15,7 +19,7 @@ function isUsing(dep, bin, value, scripts) {
   return scripts.some(script =>
     script.indexOf(bin) === 0 ||
     script.indexOf(`./node_modules/.bin/${bin}`) !== -1 ||
-    script.indexOf(path.join('node_modules', dep, value)) !== -1);
+    script.indexOf(join('node_modules', dep, value)) !== -1);
 }
 
 function depsUsedByScripts(deps, scripts, dir) {

--- a/test/e2e.js
+++ b/test/e2e.js
@@ -9,7 +9,7 @@ function testE2E(module, output) {
     const binary = path.resolve(__dirname, '../bin/depcheck');
     const modulePath = path.resolve(__dirname, 'fake_modules', module);
 
-    exec(`${binary} ${modulePath}`, (error, stdout, stderr) => {
+    exec(`node ${binary} ${modulePath}`, (error, stdout, stderr) => {
       const expectedStdOut = output.map(line => line + '\n').join('');
 
       stdout.should.equal(expectedStdOut);

--- a/test/fake_parsers/importList.js
+++ b/test/fake_parsers/importList.js
@@ -8,7 +8,7 @@ function toRequire(dep) {
 }
 
 export function lite(content) {
-  return content.split('\n').filter(line => line);
+  return content.replace(/\r\n/g, '\n').split('\n').filter(line => line);
 }
 
 export function full(content) {

--- a/test/fake_parsers/multiple.js
+++ b/test/fake_parsers/multiple.js
@@ -1,5 +1,6 @@
 function parser(prefix, content) {
   return content
+    .replace(/\r\n/g, '\n')
     .split('\n')
     .filter(line => line.startsWith(prefix))
     .map(line => ({

--- a/test/index.js
+++ b/test/index.js
@@ -4,7 +4,7 @@ import 'should';
 import depcheck from '../src/index';
 import fs from 'fs';
 import path from 'path';
-
+import { platform } from 'os';
 
 import {
   full as importListParser,
@@ -67,6 +67,10 @@ describe('depcheck', () => {
 
   function testAccessUnreadableDirectory(
     module, unreadable, unusedDeps, unusedDevDeps) {
+    if (platform() === 'win32') {
+      return; // cannot test permission cases in Windows
+    }
+
     const unreadablePath =
       path.resolve(__dirname, 'fake_modules', module, unreadable);
 
@@ -106,6 +110,10 @@ describe('depcheck', () => {
 
   function testAccessUnreadableFile(
     module, unreadable, unusedDeps, unusedDevDeps) {
+    if (platform() === 'win32') {
+      return; // cannot test permission cases in Windows
+    }
+
     const unreadablePath =
       path.resolve(__dirname, 'fake_modules', module, unreadable);
 

--- a/test/index.js
+++ b/test/index.js
@@ -46,7 +46,8 @@ describe('depcheck', () => {
 
       const invalidFiles = Object.keys(unused.invalidFiles);
       invalidFiles.should.have.length(1);
-      invalidFiles[0].should.endWith('/test/fake_modules/bad_js/index.js');
+      invalidFiles[0].should.endWith(
+        path.join('/test/fake_modules/bad_js/index.js'));
 
       const error = unused.invalidFiles[invalidFiles[0]];
       error.should.be.instanceof(SyntaxError);
@@ -208,6 +209,6 @@ describe('depcheck', () => {
 
       Object.keys(unused.invalidFiles).should.have.length(1);
       Object.keys(unused.invalidFiles)[0].should.endWith(
-        '/test/fake_modules/import_list/index.txt');
+        path.join('/test/fake_modules/import_list/index.txt'));
     }));
 });


### PR DESCRIPTION
- Integrate AppVeyor CI into build pipeline. So further commit won't break Windows support.
- Update README to include AppVeyor build status badge
- Resolve some bad test codes to let them run-able on Windows
- Skip the permission test cases on Windows
- Resolve #71 
