### PR TITLE
support scoped packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "js-yaml": "^3.4.2",
     "minimatch": "^3.0.0",
     "node-source-walk": "^2.0.0",
+    "require-package-name": "^2.0.1",
     "walkdir": "0.0.10",
     "yargs": "^3.26.0"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import Walker from 'node-source-walk';
 import walkdir from 'walkdir';
 import minimatch from 'minimatch';
 import component from './component';
+import requirePackageName from 'require-package-name';
 
 function constructComponent(source, name) {
   return source[name].reduce((result, current) =>
@@ -115,7 +116,7 @@ function getDependencies(dir, filename, deps, parser, detectors) {
       dependencies = dependencies.concat(...results);
     });
 
-    return dependencies.map(dependency => dependency.replace(/\/.*$/, ''));
+    return dependencies.map(requirePackageName);
   });
 }
 

--- a/test/fake_modules/scoped_module/index.js
+++ b/test/fake_modules/scoped_module/index.js
@@ -1,0 +1,13 @@
+/* eslint-disable no-unused-vars */
+
+/**
+ * This covers various ways module names can be found in require statements.
+ * Module names are extracted using https://github.com/mattdesl/require-package-name
+ */
+
+const pkg = require('@owner/package');
+const anotherPackage = require('@secondowner/package');
+const childDep = require('@org/parent/child');
+const name = require('name-import/name');
+const deepName = require('child-import/deep/name');
+

--- a/test/fake_modules/scoped_module/package.json
+++ b/test/fake_modules/scoped_module/package.json
@@ -1,0 +1,10 @@
+{
+  "dependencies": {
+    "@owner/package": "~0.6.0",
+    "@secondowner/package": "~0.6.0",
+    "@org/parent": "~0.6.0",
+    "@unused/package": "~0.6.0",
+    "name-import": "1.2.3",
+    "child-import": "1.2.3"
+  }
+}

--- a/test/spec.json
+++ b/test/spec.json
@@ -179,5 +179,15 @@
       "dependencies": [],
       "devDependencies": []
     }
+  },
+  {
+    "name": "support scoped modules",
+    "module": "scoped_module",
+    "options": {
+    },
+    "expected": {
+      "dependencies": ["@unused/package"],
+      "devDependencies": []
+    }
   }
 ]


### PR DESCRIPTION
Supports scoped packages in the format of `@user/package-name`.

Required for https://github.com/dylang/npm-check/issues/35
