### PR TITLE
Disable NPM cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
 language: node_js
 
-cache:
-  directories:
-    - node_modules
-
 node_js:
   - '0.10'
   - '0.12'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,7 @@ environment:
 
 install:
   - ps: Install-Product node $env:nodejs_version
+  - npm -g install npm@3 && set PATH=%APPDATA%\npm;%PATH%
   - npm install
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,9 +5,6 @@ environment:
   - nodejs_version: '3'
   - nodejs_version: '4'
 
-cache:
-  - node_modules -> package.json
-
 install:
   - ps: Install-Product node $env:nodejs_version
   - npm install


### PR DESCRIPTION
- Disable NPM cache to enjoy newest compatible packages.
- Force to use NPM 3.x in AppVeyor CI, avoid deep folder hierarchy.
