### PR TITLE
Test case to assert ignore require number.

### DIFF
--- a/test/fake_modules/ignore_number/index.js
+++ b/test/fake_modules/ignore_number/index.js
@@ -1,0 +1,9 @@
+/*
+ * Require number is used in minify tools (e.g., browserify, webpack).
+ * However, number is not a valid package for NPM.
+ * Reference: https://docs.npmjs.com/files/package.json#name
+ */
+
+require(1);
+require(2);
+require(3);

--- a/test/fake_modules/ignore_number/package.json
+++ b/test/fake_modules/ignore_number/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "number": "1.2.3"
+  }
+}

--- a/test/spec.json
+++ b/test/spec.json
@@ -189,5 +189,15 @@
       "dependencies": ["@unused/package"],
       "devDependencies": []
     }
+  },
+  {
+    "name": "ignore require number",
+    "module": "ignore_number",
+    "options": {
+    },
+    "expected": {
+      "dependencies": ["number"],
+      "devDependencies": []
+    }
   }
 ]


### PR DESCRIPTION
- Depcheck should handle the require number statements.
- However, these statements should be ignored.
- See this comment: https://github.com/lijunle/depcheck-es6/pull/76#issuecomment-148088612
