### PR TITLE
Support CoffeeScript

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "acorn": "^2.4.0",
     "acorn-jsx": "^2.0.0",
     "babel-runtime": "^5.8.25",
+    "coffee-script": "^1.10.0",
     "js-yaml": "^3.4.2",
     "minimatch": "^3.0.0",
     "node-source-walk": "^2.0.0",

--- a/src/component.json
+++ b/src/component.json
@@ -2,6 +2,7 @@
   "notice": "This file is for debugging and testing only, the production one is built from `build/component.js` script.",
   "parser": [
     "es6",
+    "coffee",
     "jsx"
   ],
   "detector": [

--- a/src/index.js
+++ b/src/index.js
@@ -35,6 +35,9 @@ const defaultOptions = {
   parsers: {
     '*.js': availableParsers.es6,
     '*.jsx': availableParsers.jsx,
+    '*.coffee': availableParsers.coffee,
+    '*.litcoffee': availableParsers.coffee,
+    '*.coffee.md': availableParsers.coffee,
   },
   detectors: [
     availableDetectors.importDeclaration,

--- a/src/parser/coffee.js
+++ b/src/parser/coffee.js
@@ -1,0 +1,5 @@
+import * as acorn from 'acorn';
+import coffee from 'coffee-script';
+
+export default content =>
+  acorn.parse(coffee.compile(content), { sourceType: 'module' });

--- a/test/fake_modules/coffee_script/index.coffee
+++ b/test/fake_modules/coffee_script/index.coffee
@@ -1,0 +1,26 @@
+require 'coffee'
+
+# These are some CoffeeScript code snippets copied from its site.
+# The CoffeeScript syntax should be recognized.
+
+# Conditions:
+number = -42 if opposite
+
+# Functions:
+square = (x) -> x * x
+
+# Objects:
+math =
+  root:   Math.sqrt
+  square: square
+  cube:   (x) -> x * square x
+
+# Splats:
+race = (winner, runners...) ->
+  print winner, runners
+
+# Existence:
+alert "I knew it!" if elvis?
+
+# Array comprehensions:
+cubes = (math.cube num for num in list)

--- a/test/fake_modules/coffee_script/package.json
+++ b/test/fake_modules/coffee_script/package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "tea": "1.2.3",
+    "coffee": "1.2.3"
+  }
+}

--- a/test/spec.json
+++ b/test/spec.json
@@ -181,6 +181,16 @@
     }
   },
   {
+    "name": "support CoffeeScript syntax",
+    "module": "coffee_script",
+    "options": {
+    },
+    "expected": {
+      "dependencies": ["tea"],
+      "devDependencies": []
+    }
+  },
+  {
     "name": "support scoped modules",
     "module": "scoped_module",
     "options": {


### PR DESCRIPTION
- CoffeeScript provide its own AST which is not compatiblw the JavaScript AST.
- I find the easiest way to support CoffeeScript is to compile CoffeeScript to JavaScript, then convert it to AST.
- The performance may be bad, however it works.
- Resolve #80 
