### PR TITLE
Treat parser returned packages as dependencies directly.

### DIFF
--- a/test/fake_parsers/importList.js
+++ b/test/fake_parsers/importList.js
@@ -2,6 +2,7 @@ function toRequire(dep) {
   return {
     type: 'ImportDeclaration',
     source: {
+      type: 'Literal',
       value: dep,
     },
   };

--- a/test/fake_parsers/multiple.js
+++ b/test/fake_parsers/multiple.js
@@ -6,6 +6,7 @@ function parser(prefix, content) {
     .map(line => ({
       type: 'ImportDeclaration',
       source: {
+        type: 'Literal',
         value: line.substring(prefix.length),
       },
     }));

--- a/test/index.js
+++ b/test/index.js
@@ -174,6 +174,9 @@ describe('depcheck', () => {
       parsers: {
         '*.txt': importListParserLite,
       },
+      detectors: [
+        // the detector step is skipped because parser returns string array
+      ],
     }));
 
   it('should support multiple parsers to generate ASTs', () =>


### PR DESCRIPTION
- When parser returns string array, skip detector step and treat them as dependencies directly.
- Follow the design change in #100 
- Update unit test to ensure the change.
