### PR TITLE
Support Babel ES7 Syntax.

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,9 +29,8 @@
   "license": "MIT",
   "readmeFilename": "README.md",
   "dependencies": {
-    "acorn": "^2.4.0",
-    "acorn-jsx": "^2.0.0",
     "babel-runtime": "^5.8.25",
+    "babylon": "^5.8.29",
     "deps-regex": "^0.1.4",
     "js-yaml": "^3.4.2",
     "minimatch": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "deps-regex": "^0.1.4",
     "js-yaml": "^3.4.2",
     "minimatch": "^3.0.0",
-    "node-source-walk": "^2.0.0",
     "request": "^2.65.0",
     "require-package-name": "^2.0.1",
     "walkdir": "0.0.10",

--- a/src/parser/es6.js
+++ b/src/parser/es6.js
@@ -1,8 +1,23 @@
-import * as acorn from 'acorn';
+import { parse } from 'babylon';
+
+export const config = {
+  sourceType: 'module',
+  features: {
+    // Enable all possible experimental features.
+    // Because we only parse them, not evaluate any code, it is safe to do so.
+    // Reference Babel docs: https://babeljs.io/docs/usage/experimental/
+    'es7.asyncFunctions': true,
+    'es7.classProperties': true,
+    'es7.comprehensions': true,
+    'es7.decorators': true,
+    'es7.doExpressions': true,
+    'es7.exponentiationOperator': true,
+    'es7.exportExtensions': true,
+    'es7.functionBind': true,
+    'es7.objectRestSpread': true,
+    'es7.trailingFunctionCommas': true,
+  },
+};
 
 export default content =>
-  acorn.parse(content, {
-    ecmaVersion: 6,
-    sourceType: 'module',
-    allowHashBang: true,
-  });
+  parse(content, config);

--- a/src/parser/jsx.js
+++ b/src/parser/jsx.js
@@ -1,9 +1,8 @@
-import * as acorn from 'acorn-jsx';
+import { parse } from 'babylon';
+import { config } from './es6';
 
 export default content =>
-  acorn.parse(content, {
-    ecmaVersion: 6,
-    sourceType: 'module',
-    allowHashBang: true,
+  parse(content, {
+    ...config,
     plugins: { jsx: true },
   });

--- a/src/utils/get-nodes.js
+++ b/src/utils/get-nodes.js
@@ -1,0 +1,24 @@
+function recursive(ast, visited) {
+  const nodes = [];
+
+  if (ast && ast.type && !visited.has(ast)) {
+    visited.add(ast);
+    nodes.push(ast);
+  }
+
+  if (Array.isArray(ast)) {
+    return nodes.concat(...ast.map(node => recursive(node, visited)));
+  } else if (ast && typeof ast === 'object') {
+    return nodes.concat(...Object.keys(ast)
+      .filter(key => key !== 'tokens' && key !== 'comments')
+      .map(key => recursive(ast[key], visited)));
+  }
+
+  return nodes;
+}
+
+export default function getNodes(ast) {
+  const visited = new WeakSet();
+  const nodes = recursive(ast, visited);
+  return nodes;
+}

--- a/test/fake_modules/good_es7/index.js
+++ b/test/fake_modules/good_es7/index.js
@@ -1,0 +1,16 @@
+/* eslint-disable no-unused-vars */
+
+// This file includes some experimental ES7 syntax enabled in Babel by default. Reference: https://babeljs.io/docs/usage/experimental/
+
+import 'ecmascript-rest-spread';
+
+const test = {
+  x: 1,
+  y: 2,
+  z: 3,
+};
+
+const objectRestSpread = {
+  ...test,
+  spec: 'https://github.com/sebmarkbage/ecmascript-rest-spread',
+};

--- a/test/fake_modules/good_es7/package.json
+++ b/test/fake_modules/good_es7/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "ecmascript-rest-spread": "0.0.1"
+  }
+}

--- a/test/spec.json
+++ b/test/spec.json
@@ -45,6 +45,17 @@
     "notice": "See `good_es6/index.js` file for more information on the unsupported ES6 import syntax, which we assert here as the expected missing import."
   },
   {
+    "name": "recognize experimental ES7 syntax enabled in Babel by default",
+    "module": "good_es7",
+    "options": {
+      "withoutDev": true
+    },
+    "expected": {
+      "dependencies": [],
+      "devDependencies": []
+    }
+  },
+  {
     "name": "find grunt dependencies",
     "module": "grunt",
     "options": {


### PR DESCRIPTION
- Fully support Babel ES7 experimental syntax - leverage Babel parser [babylon](https://github.com/babel/babel/tree/master/packages/babylon).
- Add simple unit test to support Babel ES7 syntax.
- Implement the AST walker by hand - not depend on node-source-walk any more.
